### PR TITLE
Improve cloid parsing performance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3064,6 +3064,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f00cc9702ca12d3c81455259621e676d0f7251cec66a21e98fe2e9a37db93b2a"
 dependencies = [
  "getrandom",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ repository = "https://github.com/hyperliquid-dex/hyperliquid-rust-sdk"
 [dependencies]
 chrono = "0.4.26"
 env_logger = "0.10.0"
-ethers = {version = "0.17", features = ["eip712", "abigen"]}
+ethers = { version = "0.17", features = ["eip712", "abigen"] }
 futures-util = "0.3.28"
 hex = "0.4.3"
 http = "0.2.9"
@@ -22,10 +22,10 @@ lazy_static = "1.3"
 log = "0.4.19"
 rand = "0.8.5"
 reqwest = "0.11.18"
-serde = {version = "1.0.175", features = ["derive"]}
+serde = { version = "1.0.175", features = ["derive"] }
 serde_json = "1.0.103"
 rmp-serde = "1.0.0"
 thiserror = "1.0.44"
-tokio = {version = "1.29.1", features = ["full"]}
-tokio-tungstenite = {version = "0.20.0", features = ["native-tls"]}
-uuid = {version = "1.6.1", features = ["v4"]}
+tokio = { version = "1.29.1", features = ["full"] }
+tokio-tungstenite = { version = "0.20.0", features = ["native-tls"] }
+uuid = { version = "1.6.1", features = ["v4", "serde"] }

--- a/src/exchange/cancel.rs
+++ b/src/exchange/cancel.rs
@@ -1,3 +1,4 @@
+use crate::helpers::as_hex;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -22,5 +23,6 @@ pub struct ClientCancelRequestCloid {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct CancelRequestCloid {
     pub asset: u32,
-    pub cloid: String,
+    #[serde(serialize_with = "as_hex")]
+    pub cloid: Uuid,
 }

--- a/src/exchange/exchange_client.rs
+++ b/src/exchange/exchange_client.rs
@@ -7,7 +7,7 @@ use crate::{
         cancel::{CancelRequest, CancelRequestCloid},
         ClientCancelRequest, ClientOrderRequest,
     },
-    helpers::{generate_random_key, next_nonce, uuid_to_hex_string, EthChain},
+    helpers::{generate_random_key, next_nonce, EthChain},
     info::info_client::InfoClient,
     meta::Meta,
     prelude::*,
@@ -262,7 +262,7 @@ impl ExchangeClient {
                 .ok_or(Error::AssetNotFound)?;
             transformed_cancels.push(CancelRequestCloid {
                 asset,
-                cloid: uuid_to_hex_string(cancel.cloid),
+                cloid: cancel.cloid,
             });
         }
 
@@ -423,7 +423,7 @@ mod tests {
                 order_type: Order::Limit(Limit {
                     tif: "Ioc".to_string(),
                 }),
-                cloid: Some(uuid_to_hex_string(cloid.unwrap())),
+                cloid: Some(cloid.unwrap()),
             }],
             grouping: "na".to_string(),
         });

--- a/src/exchange/order.rs
+++ b/src/exchange/order.rs
@@ -1,6 +1,6 @@
 use crate::{
     errors::Error,
-    helpers::{float_to_string_for_hashing, uuid_to_hex_string},
+    helpers::{as_hex_option, float_to_string_for_hashing},
     prelude::*,
 };
 use serde::{Deserialize, Serialize};
@@ -42,8 +42,13 @@ pub struct OrderRequest {
     pub reduce_only: bool,
     #[serde(rename = "t", alias = "orderType")]
     pub order_type: Order,
-    #[serde(rename = "c", alias = "cloid", skip_serializing_if = "Option::is_none")]
-    pub cloid: Option<String>,
+    #[serde(
+        rename = "c",
+        alias = "cloid",
+        serialize_with = "as_hex_option",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub cloid: Option<Uuid>,
 }
 
 pub struct ClientLimit {
@@ -82,8 +87,6 @@ impl ClientOrderRequest {
         };
         let &asset = coin_to_asset.get(&self.asset).ok_or(Error::AssetNotFound)?;
 
-        let cloid = self.cloid.map(uuid_to_hex_string);
-
         Ok(OrderRequest {
             asset,
             is_buy: self.is_buy,
@@ -91,7 +94,7 @@ impl ClientOrderRequest {
             limit_px: float_to_string_for_hashing(self.limit_px),
             sz: float_to_string_for_hashing(self.sz),
             order_type,
-            cloid,
+            cloid: self.cloid,
         })
     }
 }


### PR DESCRIPTION
Conversion of  `cloid` from `Uuid` to hex string can be improved  by ~2.3x. This PR does some internal optimization on the conversion by using [uuid.simple()](https://docs.rs/uuid/latest/uuid/struct.Uuid.html#method.simple) function to represent the the random generated value.
It also makes use of serde `serialize_with` variant to ease on serializing cloid without having to import  the utility helper function allover the codebase 


### Benches

```
// Current implementation

Benchmarking uuid v4
Benchmarking uuid v4: Warming up for 3.0000 s
Benchmarking uuid v4: Collecting 100 samples in estimated 5.0071 s (2388650 iterations)
Benchmarking uuid v4: Analyzing
uuid v4                 time:   [2.0797 µs 2.0876 µs 2.0954 µs]
                        change: [+0.1580% +0.6380% +1.1368%] (p = 0.01 < 0.05)
                        Change within noise threshold.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe
slope  [2.0797 µs 2.0954 µs] R^2            [0.9651618 0.9652152]
mean   [2.0785 µs 2.0915 µs] std. dev.      [27.607 ns 40.760 ns]
median [2.0717 µs 2.0904 µs] med. abs. dev. [22.321 ns 39.474 ns]
```

```
// New implementation
Benchmarking uuid v4 simple
Benchmarking uuid v4 simple: Warming up for 3.0000 s
Benchmarking uuid v4 simple: Collecting 100 samples in estimated 5.0023 s (5494400 iterations)
Benchmarking uuid v4 simple: Analyzing
uuid v4 simple          time:   [916.89 ns 922.67 ns 928.48 ns]
slope  [916.89 ns 928.48 ns] R^2            [0.9310848 0.9310264]
mean   [927.75 ns 936.43 ns] std. dev.      [19.434 ns 24.910 ns]
median [929.27 ns 940.77 ns] med. abs. dev. [12.886 ns 24.725 ns]
```



### Samples to Reproduce
```
// Current
#[derive(Serialize)]
pub struct ClientOrderRequest {
    pub cloid: Option<String>,
}

#[inline]
pub fn cloid_with_uuid() -> String {
    let uuid = Uuid::new_v4();

    let cloid = uuid_to_hex_string(uuid);

    serde_json::to_value(ClientOrderRequest { cloid: Some(cloid) })
        .unwrap()
        .to_string()
}

pub fn uuid_to_hex_string(uuid: Uuid) -> String {
    let hex_string = uuid
        .as_bytes()
        .iter()
        .map(|byte| format!("{:02x}", byte))
        .collect::<Vec<String>>()
        .join("");
    format!("0x{}", hex_string)
}
```


```
// New
#[derive(Serialize)]
pub struct ClientOrderRequest {
    #[serde(serialize_with = "as_hex_option")]
    pub cloid: Option<Uuid>,
}

#[inline]
pub fn cloid_with_uuid_simple() -> String {
    let cloid = Uuid::new_v4();

    serde_json::to_value(ClientOrderRequest { cloid: Some(cloid) })
        .unwrap()
        .to_string()
}

pub fn as_hex_option<S>(cloid: &Option<Uuid>, s: S) -> Result<S::Ok, S::Error>
where
    S: Serializer,
{
    if let Some(cloid) = cloid {
        s.serialize_str(&format!("0x{}", cloid.simple()))
    } else {
        s.serialize_none()
    }
}
```