### PR TITLE
Add a NAME/USDC to spot index mapping to the coin_to_asset HashMap

### DIFF
--- a/src/bin/spot_order.rs
+++ b/src/bin/spot_order.rs
@@ -20,11 +20,11 @@ async fn main() {
         .unwrap();
 
     let order = ClientOrderRequest {
-        asset: "PURR/USDC".to_string(),
+        asset: "XYZTWO/USDC".to_string(),
         is_buy: true,
         reduce_only: false,
-        limit_px: 78.4,
-        sz: 10.0,
+        limit_px: 0.00002378,
+        sz: 1000000.0,
         cloid: None,
         order_type: ClientOrder::Limit(ClientLimit {
             tif: "Gtc".to_string(),
@@ -49,7 +49,7 @@ async fn main() {
     sleep(Duration::from_secs(10));
 
     let cancel = ClientCancelRequest {
-        asset: "PURR/USDC".to_string(),
+        asset: "HFUN/USDC".to_string(),
         oid,
     };
 

--- a/src/exchange/exchange_client.rs
+++ b/src/exchange/exchange_client.rs
@@ -1,4 +1,3 @@
-use crate::meta::SpotMeta;
 use crate::signature::sign_typed_data;
 use crate::{
     exchange::{
@@ -96,17 +95,15 @@ impl ExchangeClient {
             info.meta().await?
         };
 
-        let spot_meta: SpotMeta = info.spot_meta().await?;
-
         let mut coin_to_asset = HashMap::new();
         for (asset_ind, asset) in meta.universe.iter().enumerate() {
             coin_to_asset.insert(asset.name.clone(), asset_ind as u32);
         }
 
-        for asset in spot_meta.universe.into_iter() {
-            let spot_ind: u32 = 10000 + asset.index as u32;
-            coin_to_asset.insert(asset.name, spot_ind);
-        }
+        coin_to_asset = info
+            .spot_meta()
+            .await?
+            .add_pair_and_name_to_index_map(coin_to_asset);
 
         Ok(ExchangeClient {
             wallet,

--- a/src/meta.rs
+++ b/src/meta.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use ethers::abi::ethereum_types::H128;
 use serde::Deserialize;
 
@@ -10,6 +12,40 @@ pub struct Meta {
 pub struct SpotMeta {
     pub universe: Vec<SpotAssetMeta>,
     pub tokens: Vec<TokenInfo>,
+}
+
+impl SpotMeta {
+    pub fn add_pair_and_name_to_index_map(
+        &self,
+        mut coin_to_asset: HashMap<String, u32>,
+    ) -> HashMap<String, u32> {
+        let index_to_name: HashMap<usize, &str> = self
+            .tokens
+            .iter()
+            .map(|info| (info.index, info.name.as_str()))
+            .collect();
+
+        for asset in self.universe.iter() {
+            let spot_ind: u32 = 10000 + asset.index as u32;
+            let name_to_ind = (asset.name.clone(), spot_ind);
+
+            let token_1_name = if let Some(name) = index_to_name.get(asset.tokens.get(0).unwrap()) {
+                name
+            } else {
+                "" // Keeping these empty because the user won't be able to match then so no harm
+            };
+            let token_2_name = if let Some(name) = index_to_name.get(asset.tokens.get(1).unwrap()) {
+                name
+            } else {
+                ""
+            };
+
+            coin_to_asset.insert(format!("{}/{}", token_1_name, token_2_name), spot_ind);
+            coin_to_asset.insert(name_to_ind.0, name_to_ind.1);
+        }
+
+        coin_to_asset
+    }
 }
 
 #[derive(Deserialize, Debug, Clone)]

--- a/src/meta.rs
+++ b/src/meta.rs
@@ -29,15 +29,12 @@ impl SpotMeta {
             let spot_ind: u32 = 10000 + asset.index as u32;
             let name_to_ind = (asset.name.clone(), spot_ind);
 
-            let token_1_name = if let Some(name) = index_to_name.get(&asset.tokens[0]) {
-                name
-            } else {
-                "" // Keeping these empty because the user won't be able to match then so no harm
+            let Some(token_1_name) = index_to_name.get(&asset.tokens[0]) else {
+                continue;
             };
-            let token_2_name = if let Some(name) = index_to_name.get(&asset.tokens[1]) {
-                name
-            } else {
-                ""
+
+            let Some(token_2_name) = index_to_name.get(&asset.tokens[1]) else {
+                continue;
             };
 
             coin_to_asset.insert(format!("{}/{}", token_1_name, token_2_name), spot_ind);

--- a/src/meta.rs
+++ b/src/meta.rs
@@ -29,12 +29,12 @@ impl SpotMeta {
             let spot_ind: u32 = 10000 + asset.index as u32;
             let name_to_ind = (asset.name.clone(), spot_ind);
 
-            let token_1_name = if let Some(name) = index_to_name.get(asset.tokens.get(0).unwrap()) {
+            let token_1_name = if let Some(name) = index_to_name.get(&asset.tokens[0]) {
                 name
             } else {
                 "" // Keeping these empty because the user won't be able to match then so no harm
             };
-            let token_2_name = if let Some(name) = index_to_name.get(asset.tokens.get(1).unwrap()) {
+            let token_2_name = if let Some(name) = index_to_name.get(&asset.tokens[1]) {
                 name
             } else {
                 ""


### PR DESCRIPTION
To allow spot ordering with NAME/USDC when placing spot orders