### PR TITLE
Fix #45: Send errors as Messages over subscription sender channel

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,7 +1,7 @@
 use reqwest::header::HeaderMap;
 use thiserror::Error;
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Clone)]
 pub enum Error {
     // TODO: turn some embedded types into errors instead of strings
     #[error("Client error: status code: {status_code}, error code: {error_code:?}, error message: {error_message}, headers: {headers:?}, error data: {error_data:?}")]

--- a/src/ws/ws_manager.rs
+++ b/src/ws/ws_manager.rs
@@ -208,13 +208,9 @@ impl WsManager {
                         }
                         res
                     }
-                    Err(err) => {
-                        Err(Error::ReaderTextConversion(err.to_string()))
-                    }
+                    Err(err) => Err(Error::ReaderTextConversion(err.to_string()))
                 },
-                Err(err) => {
-                    Err(Error::GenericReader(err.to_string()))
-                }
+                Err(err) => Err(Error::GenericReader(err.to_string()))
             },
             None => {
                 let mut subscriptions = subscriptions.lock().await;

--- a/src/ws/ws_manager.rs
+++ b/src/ws/ws_manager.rs
@@ -170,7 +170,7 @@ impl WsManager {
             }
             Message::Notification(_) => Ok("notification".to_string()),
             Message::SubscriptionResponse | Message::Pong => Ok(String::default()),
-            Message::WsError(_) => Ok(format!("error")),
+            Message::WsError(_) => Ok("error".to_string()),
             Message::NoData => Ok(String::default()),
         }
     }
@@ -209,11 +209,11 @@ impl WsManager {
                         res
                     }
                     Err(err) => {
-                        return Err(Error::ReaderTextConversion(err.to_string()));
+                        Err(Error::ReaderTextConversion(err.to_string()))
                     }
                 },
                 Err(err) => {
-                    return Err(Error::GenericReader(err.to_string()));
+                    Err(Error::GenericReader(err.to_string()))
                 }
             },
             None => {

--- a/src/ws/ws_manager.rs
+++ b/src/ws/ws_manager.rs
@@ -168,7 +168,7 @@ impl WsManager {
             }
             Message::Notification(_) => Ok("notification".to_string()),
             Message::SubscriptionResponse | Message::Pong => Ok(String::default()),
-            Message::NoData => Ok(String::default()),
+            Message::NoData => Ok("".to_string()),
             Message::HyperliquidError(err) => Ok(format!("hyperliquid error: {err:?}")),
         }
     }
@@ -177,7 +177,6 @@ impl WsManager {
         data: Option<std::result::Result<protocol::Message, tungstenite::Error>>,
         subscriptions: &Arc<Mutex<HashMap<String, Vec<SubscriptionData>>>>,
     ) -> Result<()> {
-        // If no data
         let Some(data) = data else {
             return WsManager::send_to_all_subscriptions(subscriptions, Message::NoData).await;
         };

--- a/src/ws/ws_manager.rs
+++ b/src/ws/ws_manager.rs
@@ -53,6 +53,10 @@ pub enum Subscription {
 #[serde(tag = "channel")]
 #[serde(rename_all = "camelCase")]
 pub enum Message {
+    #[serde(skip_serializing)]
+    NoData,
+    #[serde(skip_serializing)]
+    WsError(String),
     AllMids(AllMids),
     Trades(Trades),
     L2Book(L2Book),
@@ -166,6 +170,8 @@ impl WsManager {
             }
             Message::Notification(_) => Ok("notification".to_string()),
             Message::SubscriptionResponse | Message::Pong => Ok(String::default()),
+            Message::WsError(_) => Ok(format!("error")),
+            Message::NoData => Ok(String::default()),
         }
     }
 
@@ -173,35 +179,64 @@ impl WsManager {
         data: Option<std::result::Result<protocol::Message, tungstenite::Error>>,
         subscriptions: &Arc<Mutex<HashMap<String, Vec<SubscriptionData>>>>,
     ) -> Result<()> {
-        let data = data
-            .ok_or(Error::ReaderDataNotFound)?
-            .map_err(|e| Error::GenericReader(e.to_string()))?
-            .into_text()
-            .map_err(|e| Error::ReaderTextConversion(e.to_string()))?;
-        if !data.starts_with('{') {
-            return Ok(());
-        }
-        let message =
-            serde_json::from_str::<Message>(&data).map_err(|e| Error::JsonParse(e.to_string()))?;
-        let identifier = WsManager::get_identifier(&message)?;
-        if identifier.is_empty() {
-            return Ok(());
-        }
+        match data {
+            Some(data) => {
+                match data {
+                    Ok(data) => {
+                        match data.into_text() {
+                            Ok(data) => {
+                                if !data.starts_with('{') {
+                                    return Ok(());
+                                }
+                                let message =
+                                    serde_json::from_str::<Message>(&data).map_err(|e| Error::JsonParse(e.to_string()))?;
+                                let identifier = WsManager::get_identifier(&message)?;
+                                if identifier.is_empty() {
+                                    return Ok(());
+                                }
 
-        let mut subscriptions = subscriptions.lock().await;
-        let mut res = Ok(());
-        if let Some(subscription_datas) = subscriptions.get_mut(&identifier) {
-            for subscription_data in subscription_datas {
-                if let Err(e) = subscription_data
-                    .sending_channel
-                    .send(message.clone())
-                    .map_err(|e| Error::WsSend(e.to_string()))
-                {
-                    res = Err(e);
+                                let mut subscriptions = subscriptions.lock().await;
+                                let mut res = Ok(());
+                                if let Some(subscription_datas) = subscriptions.get_mut(&identifier) {
+                                    for subscription_data in subscription_datas {
+                                        if let Err(e) = subscription_data
+                                            .sending_channel
+                                            .send(message.clone())
+                                            .map_err(|e| Error::WsSend(e.to_string()))
+                                        {
+                                            res = Err(e);
+                                        }
+                                    }
+                                }
+                                res
+                            }
+                            Err(err) => {
+                                return Err(Error::ReaderTextConversion(err.to_string()));
+                            }
+                        }
+                    }
+                    Err(err) => {
+                        return Err(Error::GenericReader(err.to_string()));
+                    }
                 }
             }
+            None => {
+                let mut subscriptions = subscriptions.lock().await;
+                let mut res = Ok(());
+                for (_, subs_data) in subscriptions.iter_mut() {
+                    for subscription_data in subs_data {
+                        if let Err(e) = subscription_data
+                            .sending_channel
+                            .send(Message::NoData)
+                            .map_err(|e| Error::WsSend(e.to_string()))
+                        {
+                            res = Err(e);
+                        }
+                    }
+                }
+                res
+            }
         }
-        res
     }
 
     pub(crate) async fn add_subscription(

--- a/src/ws/ws_manager.rs
+++ b/src/ws/ws_manager.rs
@@ -179,7 +179,7 @@ impl WsManager {
     ) -> Result<()> {
         // If no data
         let Some(data) = data else {
-            return Ok(WsManager::send_to_all_subscriptions(subscriptions, Message::NoData).await?);
+            return WsManager::send_to_all_subscriptions(subscriptions, Message::NoData).await;
         };
 
         match data {


### PR DESCRIPTION
Fixes issue #45

This allows the developer to react to any changes in the websocket connection or handle any errors received from hyperliquid. Example: Dynamically closing and opening the websocket upon errors.

Previously the errors would just get logged and the thread would continue running.

Possible an AtomicBool to start and stop the sender thread too?