### PR TITLE
Add ws/robust, an alternative to ws_manager

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,6 @@ thiserror = "1.0.44"
 tokio = {version = "1.29.1", features = ["full"]}
 tokio-tungstenite = {version = "0.20.0", features = ["native-tls"]}
 uuid = {version = "1.6.1", features = ["v4"]}
+
+# Dependencies added by ws/robust
+anyhow = "1.0"

--- a/src/bin/ws_robust_stream_candles.rs
+++ b/src/bin/ws_robust_stream_candles.rs
@@ -1,0 +1,50 @@
+use hyperliquid_rust_sdk::{robust::Stream, BaseUrl, Message, Subscription, SubscriptionSendData};
+use std::time::Duration;
+use tokio::{spawn, sync::mpsc, time::sleep};
+
+/// Stream 1m ETH/USD candles directly without using any subscription helper
+#[tokio::main]
+async fn main() {
+    env_logger::init();
+
+    let (inbox_tx, mut inbox_rx) = mpsc::channel(100);
+
+    let (stream, handle) = Stream::connect(&BaseUrl::Mainnet, inbox_tx);
+
+    stream
+        .send(
+            serde_json::to_value(SubscriptionSendData {
+                method: "subscribe",
+                subscription: &serde_json::to_value(Subscription::Candle {
+                    coin: "ETH".to_string(),
+                    interval: "1m".to_string(),
+                })
+                .unwrap(),
+            })
+            .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    println!("Streaming ETH/USD 1m candles for 60 seconds...");
+    println!("volume\topen\thigh\tlow\tclose");
+
+    spawn(async move {
+        sleep(Duration::from_secs(60)).await;
+
+        stream.cancel().await;
+    });
+
+    while let Some(message) = inbox_rx.recv().await {
+        if let Message::Candle(candle) = message {
+            let data = candle.data;
+            // vol, open, high, low, close
+            println!(
+                "{}\t{}\t{}\t{}\t{}",
+                data.volume, data.open, data.high, data.low, data.close
+            );
+        }
+    }
+
+    handle.await.unwrap().unwrap();
+}

--- a/src/bin/ws_robust_subs_trades.rs
+++ b/src/bin/ws_robust_subs_trades.rs
@@ -1,0 +1,51 @@
+use hyperliquid_rust_sdk::Message;
+use hyperliquid_rust_sdk::{robust::Subs, BaseUrl, Subscription};
+use tokio::{
+    sync::mpsc,
+    time::{sleep, Duration},
+};
+
+/// Stream trades for BTC/USD using the subscription helper
+#[tokio::main]
+async fn main() {
+    env_logger::init();
+
+    let (subs, handle) = Subs::start(&BaseUrl::Mainnet);
+
+    let (sub_tx, mut sub_rx) = mpsc::unbounded_channel();
+
+    tokio::select! {
+        join_result = handle => join_result.unwrap().unwrap(),
+        _ = async {
+            while let Some(message) = sub_rx.recv().await {
+                if let Message::Trades(trades) = message {
+                    for trade in trades.data {
+                        println!("{} {}", trade.side, trade.px);
+                    }
+                }
+            }
+        } => {},
+        _ = async {
+                let _sub_token = subs
+                    .add(
+                        Subscription::Trades {
+                            coin: "BTC".to_string(),
+                        },
+                        sub_tx,
+                    )
+                    .await
+                    .unwrap();
+
+                println!("Streaming BTC/USD trades for 60 sec...");
+
+                sleep(Duration::from_secs(60)).await;
+
+                subs.cancel().await;
+        } => {}
+    };
+
+    // The sub token was dropped here, causing an unsubscribe
+    println!("Finished streaming. Unsubscribing and exiting in 1 sec...");
+
+    sleep(Duration::from_secs(1)).await;
+}

--- a/src/exchange/actions.rs
+++ b/src/exchange/actions.rs
@@ -1,4 +1,4 @@
-use crate::exchange::{cancel::CancelRequest, order::OrderRequest};
+use crate::exchange::{cancel::CancelRequest, modify::ModifyRequest, order::OrderRequest};
 pub(crate) use ethers::{
     abi::{encode, ParamType, Tokenizable},
     types::{
@@ -105,6 +105,12 @@ pub struct BulkOrder {
 #[serde(rename_all = "camelCase")]
 pub struct BulkCancel {
     pub cancels: Vec<CancelRequest>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct BulkModify {
+    pub modifies: Vec<ModifyRequest>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/src/exchange/exchange_client.rs
+++ b/src/exchange/exchange_client.rs
@@ -2,10 +2,11 @@ use crate::signature::sign_typed_data;
 use crate::{
     exchange::{
         actions::{
-            ApproveAgent, BulkCancel, BulkOrder, SetReferrer, UpdateIsolatedMargin, UpdateLeverage,
-            UsdSend,
+            ApproveAgent, BulkCancel, BulkModify, BulkOrder, SetReferrer, UpdateIsolatedMargin,
+            UpdateLeverage, UsdSend,
         },
         cancel::{CancelRequest, CancelRequestCloid},
+        modify::{ClientModifyRequest, ModifyRequest},
         ClientCancelRequest, ClientOrderRequest,
     },
     helpers::{generate_random_key, next_nonce, uuid_to_hex_string},
@@ -58,6 +59,8 @@ pub enum Actions {
     Order(BulkOrder),
     Cancel(BulkCancel),
     CancelByCloid(BulkCancelCloid),
+    #[serde(rename = "batchModify")]
+    Modify(BulkModify),
     ApproveAgent(ApproveAgent),
     Withdraw3(Withdraw3),
     SpotUser(SpotUser),
@@ -417,6 +420,42 @@ impl ExchangeClient {
 
         let action = Actions::Cancel(BulkCancel {
             cancels: transformed_cancels,
+        });
+        let connection_id = action.hash(timestamp, self.vault_address)?;
+
+        let action = serde_json::to_value(&action).map_err(|e| Error::JsonParse(e.to_string()))?;
+        let is_mainnet = self.http_client.is_mainnet();
+        let signature = sign_l1_action(wallet, connection_id, is_mainnet)?;
+
+        self.post(action, signature, timestamp).await
+    }
+
+    pub async fn modify(
+        &self,
+        modify: ClientModifyRequest,
+        wallet: Option<&LocalWallet>,
+    ) -> Result<ExchangeResponseStatus> {
+        self.bulk_modify(vec![modify], wallet).await
+    }
+
+    pub async fn bulk_modify(
+        &self,
+        modifies: Vec<ClientModifyRequest>,
+        wallet: Option<&LocalWallet>,
+    ) -> Result<ExchangeResponseStatus> {
+        let wallet = wallet.unwrap_or(&self.wallet);
+        let timestamp = next_nonce();
+
+        let mut transformed_modifies = Vec::new();
+        for modify in modifies.into_iter() {
+            transformed_modifies.push(ModifyRequest {
+                oid: modify.oid,
+                order: modify.order.convert(&self.coin_to_asset)?,
+            });
+        }
+
+        let action = Actions::Modify(BulkModify {
+            modifies: transformed_modifies,
         });
         let connection_id = action.hash(timestamp, self.vault_address)?;
 

--- a/src/exchange/mod.rs
+++ b/src/exchange/mod.rs
@@ -2,12 +2,14 @@ mod actions;
 mod cancel;
 mod exchange_client;
 mod exchange_responses;
+mod modify;
 mod order;
 
 pub use actions::*;
 pub use cancel::{ClientCancelRequest, ClientCancelRequestCloid};
 pub use exchange_client::*;
 pub use exchange_responses::*;
+pub use modify::{ClientModifyRequest, ModifyRequest};
 pub use order::{
     ClientLimit, ClientOrder, ClientOrderRequest, ClientTrigger, MarketCloseParams,
     MarketOrderParams, Order,

--- a/src/exchange/modify.rs
+++ b/src/exchange/modify.rs
@@ -1,0 +1,13 @@
+use super::{order::OrderRequest, ClientOrderRequest};
+use serde::{Deserialize, Serialize};
+
+pub struct ClientModifyRequest {
+    pub oid: u64,
+    pub order: ClientOrderRequest,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ModifyRequest {
+    pub oid: u64,
+    pub order: OrderRequest,
+}

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -84,7 +84,7 @@ pub enum BaseUrl {
 }
 
 impl BaseUrl {
-    pub(crate) fn get_url(&self) -> String {
+    pub fn get_url(&self) -> String {
         match self {
             BaseUrl::Localhost => LOCAL_API_URL.to_string(),
             BaseUrl::Mainnet => MAINNET_API_URL.to_string(),

--- a/src/info/info_client.rs
+++ b/src/info/info_client.rs
@@ -52,6 +52,11 @@ pub enum InfoRequest {
         user: H160,
         oid: u64,
     },
+    #[serde(rename = "orderStatus")]
+    OrderStatusByCloid {
+        user: H160,
+        oid: String,
+    },
     Meta,
     SpotMeta,
     SpotMetaAndAssetCtxs,
@@ -256,6 +261,18 @@ impl InfoClient {
 
     pub async fn query_order_by_oid(&self, address: H160, oid: u64) -> Result<OrderStatusResponse> {
         let input = InfoRequest::OrderStatus { user: address, oid };
+        self.send_info_request(input).await
+    }
+
+    pub async fn query_order_by_cloid(
+        &self,
+        address: H160,
+        cloid: String,
+    ) -> Result<OrderStatusResponse> {
+        let input = InfoRequest::OrderStatusByCloid {
+            user: address,
+            oid: cloid,
+        };
         self.send_info_request(input).await
     }
 

--- a/src/info/response_structs.rs
+++ b/src/info/response_structs.rs
@@ -53,6 +53,7 @@ pub struct UserFillsResponse {
     pub start_position: String,
     pub sz: String,
     pub time: u64,
+    pub fee: String,
 }
 
 #[derive(serde::Deserialize, Debug)]

--- a/src/info/response_structs.rs
+++ b/src/info/response_structs.rs
@@ -117,7 +117,8 @@ pub struct CandlesSnapshotResponse {
 #[derive(Deserialize, Debug)]
 pub struct OrderStatusResponse {
     pub status: String,
-    pub order: OrderInfo,
+    /// `None` if the order is not found
+    pub order: Option<OrderInfo>,
 }
 
 #[derive(Deserialize, Debug)]

--- a/src/ws/mod.rs
+++ b/src/ws/mod.rs
@@ -1,7 +1,9 @@
 mod message_types;
+pub mod robust;
 mod sub_structs;
 mod ws_manager;
 pub use message_types::*;
+pub use robust::*;
 pub use sub_structs::*;
 pub(crate) use ws_manager::WsManager;
-pub use ws_manager::{Message, Subscription};
+pub use ws_manager::{Message, Subscription, SubscriptionSendData};

--- a/src/ws/robust/mod.rs
+++ b/src/ws/robust/mod.rs
@@ -1,0 +1,5 @@
+pub mod stream;
+pub mod subs;
+
+pub use stream::*;
+pub use subs::*;

--- a/src/ws/robust/stream.rs
+++ b/src/ws/robust/stream.rs
@@ -1,0 +1,193 @@
+use crate::{ws::ws_manager::Ping, BaseUrl, Message};
+use anyhow::{anyhow, Context, Result};
+use futures_util::{
+    stream::{SplitSink, SplitStream},
+    SinkExt, StreamExt,
+};
+use log::{debug, trace};
+use serde::Serialize;
+use std::{sync::Arc, time::Duration};
+use tokio::{
+    net::TcpStream,
+    spawn,
+    sync::{mpsc, Mutex},
+    task::JoinHandle,
+    time::{interval, interval_at, Instant},
+};
+use tokio_tungstenite::{connect_async, tungstenite::protocol, MaybeTlsStream, WebSocketStream};
+
+type Socket = WebSocketStream<MaybeTlsStream<TcpStream>>;
+type Writer = SplitSink<Socket, protocol::Message>;
+type Reader = SplitStream<Socket>;
+
+pub async fn connect(base_url: &BaseUrl) -> Result<Socket> {
+    let url = format!("ws{}/ws", &BaseUrl::get_url(base_url)[4..]);
+
+    let (socket, _response) = connect_async(url).await.context("Failed to connect")?;
+
+    Ok(socket)
+}
+
+pub async fn send<C: Serialize>(writer: &mut Writer, command: C) -> Result<()> {
+    let serialized = serde_json::to_string(&command).context("Failed to serialize command")?;
+
+    trace!("--> {:?}", &serialized);
+
+    writer
+        .send(protocol::Message::Text(serialized))
+        .await
+        .context("Failed to send command")?;
+
+    Ok(())
+}
+
+// NOTE: Unknown message types are returned as None
+fn parse_message(message: protocol::Message) -> Result<Option<Message>> {
+    match message {
+        protocol::Message::Text(text) => {
+            trace!("<-- {:?}", &text);
+
+            let message = serde_json::from_str::<serde_json::Value>(&text)?;
+
+            match serde_json::from_value::<Message>(message) {
+                Ok(message) => Ok(Some(message)),
+                Err(e) => {
+                    debug!("Unhandled message: {}", e);
+
+                    Ok(None)
+                }
+            }
+        }
+        _ => Err(anyhow!("Unhandled message type: {:?}", message)),
+    }
+}
+
+const PING_INTERVAL: Duration = Duration::from_secs(50);
+const PONG_TIMEOUT: Duration = Duration::from_secs(60);
+
+pub async fn stream(
+    mut reader: Reader,
+    writer: Arc<Mutex<Writer>>,
+    tx: mpsc::Sender<Message>,
+    mut cancel_rx: mpsc::Receiver<()>,
+) -> Result<()> {
+    let mut ping_interval = interval(PING_INTERVAL);
+
+    let mut pong_interval = interval_at(Instant::now() + PONG_TIMEOUT, PONG_TIMEOUT);
+
+    loop {
+        tokio::select! {
+            message = reader.next() => match message {
+                None => {
+                    trace!("Reader stream ended");
+                    break Ok(());
+                },
+                Some(message) => match message {
+                    Err(e) => break Err(e.into()),
+                    Ok(message) => {
+                        let message = parse_message(message)?;
+
+                        if let Some(message) = message {
+                            if let Message::Pong = message {
+                                trace!("Pong received. Interval reset");
+
+                                pong_interval = interval_at(
+                                    Instant::now() + PONG_TIMEOUT,
+                                    PONG_TIMEOUT,
+                                );
+                            }
+
+                            tx.send(message).await.context("Failed to send message")?;
+                        }
+                    }
+                }
+            },
+            _ = ping_interval.tick() => {
+                send(&mut *writer.lock().await, Ping { method: "ping" }).await?;
+            },
+            // Handle pong timeout
+            _ = pong_interval.tick() => {
+                return Err(anyhow!("Pong timeout"));
+            },
+            _ = cancel_rx.recv() => {
+                trace!("Received cancel signal");
+                break Ok(());
+            }
+        }
+    }
+}
+
+pub async fn connect_and_stream(
+    base_url: &BaseUrl,
+    inbox_tx: mpsc::Sender<Message>,
+    mut outbox_rx: mpsc::Receiver<serde_json::Value>,
+    cancel_rx: mpsc::Receiver<()>,
+) -> Result<()> {
+    let socket = connect(base_url).await?;
+
+    let (writer, reader) = socket.split();
+    let writer = Arc::new(Mutex::new(writer));
+
+    tokio::select! {
+        result = stream(reader, writer.clone(), inbox_tx, cancel_rx) => result,
+        result = async {
+            while let Some(message) = outbox_rx.recv().await {
+                send(&mut *writer.lock().await, message).await?;
+            }
+
+            Ok(())
+        } =>
+            result
+
+    }
+}
+
+pub struct Stream {
+    pub outbox_tx: mpsc::Sender<serde_json::Value>,
+    cancel_tx: mpsc::Sender<()>,
+}
+
+impl Drop for Stream {
+    fn drop(&mut self) {
+        let cancel_tx = self.cancel_tx.clone();
+
+        spawn(async move {
+            let _ = cancel_tx.send(()).await;
+        });
+    }
+}
+
+impl Stream {
+    pub fn connect(
+        base_url: &BaseUrl,
+        inbox_tx: mpsc::Sender<Message>,
+    ) -> (Self, JoinHandle<Result<()>>) {
+        let (outbox_tx, outbox_rx) = mpsc::channel(100);
+        let (cancel_tx, cancel_rx) = mpsc::channel(1);
+
+        let handle = spawn({
+            let base_url = *base_url;
+
+            async move { connect_and_stream(&base_url, inbox_tx, outbox_rx, cancel_rx).await }
+        });
+
+        (
+            Self {
+                outbox_tx,
+                cancel_tx,
+            },
+            handle,
+        )
+    }
+
+    pub async fn send(&self, message: serde_json::Value) -> Result<()> {
+        self.outbox_tx
+            .send(message)
+            .await
+            .context("Failed to send message")
+    }
+
+    pub async fn cancel(&self) {
+        let _ = self.cancel_tx.send(()).await;
+    }
+}

--- a/src/ws/robust/stream.rs
+++ b/src/ws/robust/stream.rs
@@ -20,6 +20,9 @@ type Socket = WebSocketStream<MaybeTlsStream<TcpStream>>;
 type Writer = SplitSink<Socket, protocol::Message>;
 type Reader = SplitStream<Socket>;
 
+const PING_INTERVAL: Duration = Duration::from_secs(50);
+const PONG_TIMEOUT: Duration = Duration::from_secs(60);
+
 pub async fn connect(base_url: &BaseUrl) -> Result<Socket> {
     let url = format!("ws{}/ws", &BaseUrl::get_url(base_url)[4..]);
 
@@ -61,9 +64,6 @@ fn parse_message(message: protocol::Message) -> Result<Option<Message>> {
         _ => Err(anyhow!("Unhandled message type: {:?}", message)),
     }
 }
-
-const PING_INTERVAL: Duration = Duration::from_secs(50);
-const PONG_TIMEOUT: Duration = Duration::from_secs(60);
 
 pub async fn stream(
     mut reader: Reader,

--- a/src/ws/robust/subs.rs
+++ b/src/ws/robust/subs.rs
@@ -1,0 +1,266 @@
+use super::stream::Stream;
+use crate::{BaseUrl, Message, Subscription, SubscriptionSendData};
+use anyhow::Result;
+use log::{debug, error, trace};
+use serde::Serialize;
+use std::sync::{atomic::AtomicU32, Arc};
+use tokio::{
+    spawn,
+    sync::{mpsc, oneshot, RwLock},
+    task::JoinHandle,
+};
+
+type Topic = super::super::ws_manager::Subscription;
+
+// NOTE: Leaking subs can be prevented here by implementing a drop that uses a channel
+// to notify the subs manager to remove the sub. This requires Subs to have a handle
+pub type SubId = u32;
+
+pub struct Sub {
+    pub id: SubId,
+    pub topic_key: String,
+    pub topic: Topic,
+    pub tx: mpsc::UnboundedSender<Message>,
+}
+
+#[derive(Serialize, Debug)]
+pub struct Unsubscribe {
+    pub method: String,
+    pub subscription: Topic,
+}
+
+enum Command {
+    Subscribe {
+        subscription: Subscription,
+        tx: mpsc::UnboundedSender<Message>,
+        reply_tx: oneshot::Sender<SubId>,
+    },
+    Unsubscribe(SubId),
+}
+
+#[derive(Clone)]
+pub struct State {
+    id_counter: Arc<AtomicU32>,
+    subs: Arc<RwLock<Vec<Sub>>>,
+}
+
+fn get_topic_key_for_subscription(topic: &Topic) -> String {
+    match topic {
+        Subscription::UserEvents { user: _ } => "userEvents".to_string(),
+        Subscription::OrderUpdates { user: _ } => "orderUpdates".to_string(),
+        Subscription::UserFills { user: _ } => "userFills".to_string(),
+        _ => serde_json::to_string(topic).expect("Failed to convert subscription to string"),
+    }
+}
+
+async fn run(
+    outbox_tx: mpsc::Sender<serde_json::Value>,
+    mut inbox_rx: mpsc::Receiver<Message>,
+    mut command_rx: mpsc::Receiver<Command>,
+) -> Result<()> {
+    let state = State {
+        subs: Arc::new(RwLock::new(Vec::new())),
+        id_counter: Arc::new(AtomicU32::new(0)),
+    };
+
+    loop {
+        tokio::select! {
+            message = inbox_rx.recv() => {
+                match message {
+                    Some(message) => {
+                        let topic = super::super::WsManager::get_identifier(&message)?;
+                            debug!("Received message for topic: {}", topic);
+
+                            for sub in
+                                state.subs.read().await
+                                .iter()
+                                .filter(|s| s.topic_key == topic)
+                            {
+                                trace!("Sending message to sub ID={}", sub.id);
+
+                                if let Err(e) = sub.tx.send(message.clone()) {
+                                    error!(
+                                        "Failed to send message for topic {} to sub {}: {}",
+                                        topic, sub.id, e
+                                    );
+                                }
+                        }
+                    }
+                    None => {
+                        trace!("Inbox receiver closed");
+                        break Ok(());
+                    }
+                }
+            },
+            command = command_rx.recv() => {
+                match command {
+                    Some(Command::Subscribe { subscription, tx, reply_tx }) => {
+                        trace!("Received subscribe command for topic: {:?}", &subscription);
+                        let id = add(&state, outbox_tx.clone(), subscription, tx).await?;
+
+                        if let Err(e) = reply_tx.send(id) {
+                            trace!("Failed to send reply for subscribe command: {}", e);
+                        }
+                    },
+                    Some(Command::Unsubscribe(id)) => {
+                        remove(&state, outbox_tx.clone(), id).await?;
+                    },
+                    None => {}
+                }
+            },
+        }
+    }
+}
+
+async fn add(
+    state: &State,
+    outbox_tx: mpsc::Sender<serde_json::Value>,
+    topic: Topic,
+    tx: mpsc::UnboundedSender<Message>,
+) -> Result<SubId> {
+    let id = state
+        .id_counter
+        .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+
+    let topic_key = get_topic_key_for_subscription(&topic);
+
+    let sub = Sub {
+        id,
+        topic: topic.clone(),
+        topic_key: topic_key.clone(),
+        tx,
+    };
+
+    // NOTE: The mutex is held for the remainder of this function
+    let mut subs = state.subs.write().await;
+
+    debug!("Adding sub with id: {} ({})", id, topic_key);
+
+    if !subs.iter().any(|s| s.topic_key == topic_key) {
+        debug!("First subscription for this topic, sending subscribe command");
+
+        outbox_tx
+            .send(
+                serde_json::to_value(SubscriptionSendData {
+                    method: "subscribe",
+                    subscription: &serde_json::to_value(topic).unwrap(),
+                })
+                .unwrap(),
+            )
+            .await?;
+    }
+
+    subs.push(sub);
+
+    Ok(id)
+}
+
+async fn remove(
+    state: &State,
+    outbox_tx: mpsc::Sender<serde_json::Value>,
+    sub_id: SubId,
+) -> Result<()> {
+    // Locked for the duration of this function
+    let mut subs = state.subs.write().await;
+
+    let (topic, topic_key) = subs
+        .iter()
+        .find(|s| s.id == sub_id)
+        .map(|s| (s.topic.clone(), s.topic_key.clone()))
+        .unwrap();
+
+    debug!("Removing sub with id: {} ({})", sub_id, topic_key);
+
+    subs.retain(|s| s.id != sub_id);
+
+    // Send unsub if no subs have topic_key of token.topic_key anymore
+    if !subs.iter().any(|s| s.topic_key == topic_key) {
+        debug!(
+            "Last subscriber removed. Sending unsubscribe for topic: {}",
+            topic_key
+        );
+
+        outbox_tx
+            .send(
+                serde_json::to_value(Unsubscribe {
+                    method: "unsubscribe".to_string(),
+                    subscription: topic,
+                })
+                .unwrap(),
+            )
+            .await?;
+    }
+
+    Ok(())
+}
+
+pub struct Subs {
+    stream: Stream,
+    command_tx: mpsc::Sender<Command>,
+}
+
+pub struct Token {
+    id: SubId,
+    command_tx: mpsc::Sender<Command>,
+}
+
+impl Drop for Token {
+    fn drop(&mut self) {
+        let (id, command_tx) = (self.id, self.command_tx.clone());
+
+        trace!("Dropping Token with id: {}", self.id);
+
+        spawn(async move {
+            let _ = command_tx.send(Command::Unsubscribe(id)).await;
+        });
+    }
+}
+
+impl Subs {
+    pub fn start(base_url: &BaseUrl) -> (Self, JoinHandle<Result<()>>) {
+        let (inbox_tx, inbox_rx) = mpsc::channel(100);
+        let (command_tx, command_rx) = mpsc::channel(100);
+
+        let (stream, stream_handle) = Stream::connect(base_url, inbox_tx);
+
+        let run_handle = run(stream.outbox_tx.clone(), inbox_rx, command_rx);
+
+        let handle = spawn(async {
+            tokio::select! {
+                result = stream_handle => result.unwrap(),
+                result = run_handle => result,
+            }
+        });
+
+        (Self { stream, command_tx }, handle)
+    }
+
+    pub async fn add(&self, topic: Topic, tx: mpsc::UnboundedSender<Message>) -> Result<Token> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+
+        self.command_tx
+            .send(Command::Subscribe {
+                subscription: topic,
+                tx,
+                reply_tx,
+            })
+            .await?;
+
+        let id = reply_rx.await.map_err(|e| anyhow::anyhow!(e))?;
+
+        Ok(Token {
+            id,
+            command_tx: self.command_tx.clone(),
+        })
+    }
+
+    pub async fn remove(&self, sub_id: SubId) -> Result<()> {
+        self.command_tx.send(Command::Unsubscribe(sub_id)).await?;
+
+        Ok(())
+    }
+
+    pub async fn cancel(&self) {
+        self.stream.cancel().await
+    }
+}

--- a/src/ws/ws_manager.rs
+++ b/src/ws/ws_manager.rs
@@ -45,7 +45,7 @@ pub(crate) struct WsManager {
     subscription_identifiers: HashMap<u32, String>,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(tag = "type")]
 #[serde(rename_all = "camelCase")]
 pub enum Subscription {
@@ -82,14 +82,14 @@ pub enum Message {
 }
 
 #[derive(Serialize)]
-pub(crate) struct SubscriptionSendData<'a> {
-    method: &'static str,
-    subscription: &'a serde_json::Value,
+pub struct SubscriptionSendData<'a> {
+    pub method: &'static str,
+    pub subscription: &'a serde_json::Value,
 }
 
 #[derive(Serialize)]
 pub(crate) struct Ping {
-    method: &'static str,
+    pub(crate) method: &'static str,
 }
 
 impl WsManager {
@@ -158,7 +158,7 @@ impl WsManager {
         })
     }
 
-    fn get_identifier(message: &Message) -> Result<String> {
+    pub(crate) fn get_identifier(message: &Message) -> Result<String> {
         match message {
             Message::AllMids(_) => serde_json::to_string(&Subscription::AllMids)
                 .map_err(|e| Error::JsonParse(e.to_string())),


### PR DESCRIPTION
This alternative to ws_manager with some improvements:

- The stream is not coupled to the InfoClient
- Subscriptions management is separated from the stream
- Subscriptions are dropped when the token is dropped
- The stream can be closed and does not leave dangling futures

It does not implement connection retries since this should be built on top as it requires informing subscribers that the stream is interrupted and the client is missing messages.

## TODO

- [x] Helper on `Subs` to create a `Stream` and `Subs` with one fn call
