### PR TITLE
Fix #47: Handle WsManager Drop and close the ping and reader tasks

### DIFF
--- a/src/ws/ws_manager.rs
+++ b/src/ws/ws_manager.rs
@@ -4,7 +4,7 @@ use crate::{
     Error, Notification, UserFills, UserFundings, UserNonFundingLedgerUpdates,
 };
 use futures_util::{stream::SplitSink, SinkExt, StreamExt};
-use log::{error, info, warn};
+use log::{error, warn};
 use serde::{Deserialize, Serialize};
 use std::{
     collections::HashMap,
@@ -110,7 +110,7 @@ impl WsManager {
         let subscriptions_copy = Arc::clone(&subscriptions);
 
         let reader_handle = {
-            let stop_flag1 = Arc::clone(&stop_flag);
+            let stop_flag = Arc::clone(&stop_flag);
             let reader_fut = async move {
                 // TODO: reconnect
                 while !stop_flag1.load(Ordering::Relaxed) {
@@ -125,7 +125,7 @@ impl WsManager {
         };
 
         let ping_handle = {
-            let stop_flag2 = Arc::clone(&stop_flag);
+            let stop_flag = Arc::clone(&stop_flag);
             let writer = Arc::clone(&writer);
             let ping_fut = async move {
                 while !stop_flag2.load(Ordering::Relaxed) {

--- a/src/ws/ws_manager.rs
+++ b/src/ws/ws_manager.rs
@@ -115,7 +115,9 @@ impl WsManager {
                 // TODO: reconnect
                 while !stop_flag.load(Ordering::Relaxed) {
                     let data = reader.next().await;
-                    if let Err(err) = WsManager::parse_and_send_data(data, &subscriptions_copy).await {
+                    if let Err(err) =
+                        WsManager::parse_and_send_data(data, &subscriptions_copy).await
+                    {
                         error!("Error processing data received by WS manager reader: {err}");
                     }
                 }

--- a/src/ws/ws_manager.rs
+++ b/src/ws/ws_manager.rs
@@ -6,9 +6,21 @@ use crate::{
 use futures_util::{stream::SplitSink, SinkExt, StreamExt};
 use log::{error, info};
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, sync::{atomic::{AtomicBool, Ordering}, Arc}, time::Duration};
+use std::{
+    collections::HashMap,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+    time::Duration,
+};
 use tokio::{
-    net::TcpStream, runtime::Runtime, spawn, sync::{mpsc::UnboundedSender, Mutex}, task::JoinHandle, time
+    net::TcpStream,
+    runtime::Runtime,
+    spawn,
+    sync::{mpsc::UnboundedSender, Mutex},
+    task::JoinHandle,
+    time,
 };
 use tokio_tungstenite::{
     connect_async,

--- a/src/ws/ws_manager.rs
+++ b/src/ws/ws_manager.rs
@@ -113,7 +113,7 @@ impl WsManager {
             let stop_flag = Arc::clone(&stop_flag);
             let reader_fut = async move {
                 // TODO: reconnect
-                while !stop_flag1.load(Ordering::Relaxed) {
+                while !stop_flag.load(Ordering::Relaxed) {
                     let data = reader.next().await;
                     if let Err(err) = WsManager::parse_and_send_data(data, &subscriptions_copy).await {
                         error!("Error processing data received by WS manager reader: {err}");
@@ -128,7 +128,7 @@ impl WsManager {
             let stop_flag = Arc::clone(&stop_flag);
             let writer = Arc::clone(&writer);
             let ping_fut = async move {
-                while !stop_flag2.load(Ordering::Relaxed) {
+                while !stop_flag.load(Ordering::Relaxed) {
                     match serde_json::to_string(&Ping { method: "ping" }) {
                         Ok(payload) => {
                             let mut writer = writer.lock().await;


### PR DESCRIPTION
Fixing #47 to make sure no tasks are orphaned once the WsManager is dropped.