### PR TITLE
Add missing fee field to UserFillsResponse

### DIFF
--- a/src/info/response_structs.rs
+++ b/src/info/response_structs.rs
@@ -53,6 +53,7 @@ pub struct UserFillsResponse {
     pub start_position: String,
     pub sz: String,
     pub time: u64,
+    pub fee: String,
 }
 
 #[derive(serde::Deserialize, Debug)]


### PR DESCRIPTION
See https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/info-endpoint#retrieve-a-users-fills

![image](https://github.com/user-attachments/assets/0f7a3920-6b11-406f-ba85-c580ec55bd72)
