### PR TITLE
Handle order not found from info orderStatus

### DIFF
--- a/src/info/response_structs.rs
+++ b/src/info/response_structs.rs
@@ -117,7 +117,8 @@ pub struct CandlesSnapshotResponse {
 #[derive(Deserialize, Debug)]
 pub struct OrderStatusResponse {
     pub status: String,
-    pub order: OrderInfo,
+    /// `None` if the order is not found
+    pub order: Option<OrderInfo>,
 }
 
 #[derive(Deserialize, Debug)]

--- a/src/info/response_structs.rs
+++ b/src/info/response_structs.rs
@@ -118,6 +118,7 @@ pub struct CandlesSnapshotResponse {
 pub struct OrderStatusResponse {
     pub status: String,
     /// `None` if the order is not found
+    #[serde(default)]
     pub order: Option<OrderInfo>,
 }
 


### PR DESCRIPTION
See https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/info-endpoint#query-order-status-by-oid-or-cloid

![image](https://github.com/user-attachments/assets/b3929d9e-94d6-4d42-b2a9-f90a88875321)
