### PR TITLE
Add modify order

### DIFF
--- a/src/exchange/actions.rs
+++ b/src/exchange/actions.rs
@@ -1,4 +1,4 @@
-use crate::exchange::{cancel::CancelRequest, order::OrderRequest};
+use crate::exchange::{cancel::CancelRequest, modify::ModifyRequest, order::OrderRequest};
 pub(crate) use ethers::{
     abi::{encode, ParamType, Tokenizable},
     types::{
@@ -105,6 +105,12 @@ pub struct BulkOrder {
 #[serde(rename_all = "camelCase")]
 pub struct BulkCancel {
     pub cancels: Vec<CancelRequest>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct BulkModify {
+    pub modifies: Vec<ModifyRequest>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/src/exchange/exchange_client.rs
+++ b/src/exchange/exchange_client.rs
@@ -59,8 +59,7 @@ pub enum Actions {
     Order(BulkOrder),
     Cancel(BulkCancel),
     CancelByCloid(BulkCancelCloid),
-    #[serde(rename = "batchModify")]
-    Modify(BulkModify),
+    BatchModify(BulkModify),
     ApproveAgent(ApproveAgent),
     Withdraw3(Withdraw3),
     SpotUser(SpotUser),
@@ -454,7 +453,7 @@ impl ExchangeClient {
             });
         }
 
-        let action = Actions::Modify(BulkModify {
+        let action = Actions::BatchModify(BulkModify {
             modifies: transformed_modifies,
         });
         let connection_id = action.hash(timestamp, self.vault_address)?;

--- a/src/exchange/exchange_client.rs
+++ b/src/exchange/exchange_client.rs
@@ -2,10 +2,11 @@ use crate::signature::sign_typed_data;
 use crate::{
     exchange::{
         actions::{
-            ApproveAgent, BulkCancel, BulkOrder, SetReferrer, UpdateIsolatedMargin, UpdateLeverage,
-            UsdSend,
+            ApproveAgent, BulkCancel, BulkModify, BulkOrder, SetReferrer, UpdateIsolatedMargin,
+            UpdateLeverage, UsdSend,
         },
         cancel::{CancelRequest, CancelRequestCloid},
+        modify::{ClientModifyRequest, ModifyRequest},
         ClientCancelRequest, ClientOrderRequest,
     },
     helpers::{generate_random_key, next_nonce, uuid_to_hex_string},
@@ -58,6 +59,8 @@ pub enum Actions {
     Order(BulkOrder),
     Cancel(BulkCancel),
     CancelByCloid(BulkCancelCloid),
+    #[serde(rename = "batchModify")]
+    Modify(BulkModify),
     ApproveAgent(ApproveAgent),
     Withdraw3(Withdraw3),
     SpotUser(SpotUser),
@@ -417,6 +420,42 @@ impl ExchangeClient {
 
         let action = Actions::Cancel(BulkCancel {
             cancels: transformed_cancels,
+        });
+        let connection_id = action.hash(timestamp, self.vault_address)?;
+
+        let action = serde_json::to_value(&action).map_err(|e| Error::JsonParse(e.to_string()))?;
+        let is_mainnet = self.http_client.is_mainnet();
+        let signature = sign_l1_action(wallet, connection_id, is_mainnet)?;
+
+        self.post(action, signature, timestamp).await
+    }
+
+    pub async fn modify(
+        &self,
+        modify: ClientModifyRequest,
+        wallet: Option<&LocalWallet>,
+    ) -> Result<ExchangeResponseStatus> {
+        self.bulk_modify(vec![modify], wallet).await
+    }
+
+    pub async fn bulk_modify(
+        &self,
+        modifies: Vec<ClientModifyRequest>,
+        wallet: Option<&LocalWallet>,
+    ) -> Result<ExchangeResponseStatus> {
+        let wallet = wallet.unwrap_or(&self.wallet);
+        let timestamp = next_nonce();
+
+        let mut transformed_modifies = Vec::new();
+        for modify in modifies.into_iter() {
+            transformed_modifies.push(ModifyRequest {
+                oid: modify.oid,
+                order: modify.order.convert(&self.coin_to_asset)?,
+            });
+        }
+
+        let action = Actions::Modify(BulkModify {
+            modifies: transformed_modifies,
         });
         let connection_id = action.hash(timestamp, self.vault_address)?;
 

--- a/src/exchange/mod.rs
+++ b/src/exchange/mod.rs
@@ -2,12 +2,14 @@ mod actions;
 mod cancel;
 mod exchange_client;
 mod exchange_responses;
+mod modify;
 mod order;
 
 pub use actions::*;
 pub use cancel::{ClientCancelRequest, ClientCancelRequestCloid};
 pub use exchange_client::*;
 pub use exchange_responses::*;
+pub use modify::{ClientModifyRequest, ModifyRequest};
 pub use order::{
     ClientLimit, ClientOrder, ClientOrderRequest, ClientTrigger, MarketCloseParams,
     MarketOrderParams, Order,

--- a/src/exchange/modify.rs
+++ b/src/exchange/modify.rs
@@ -1,0 +1,13 @@
+use super::{order::OrderRequest, ClientOrderRequest};
+use serde::{Deserialize, Serialize};
+
+pub struct ClientModifyRequest {
+    pub oid: u64,
+    pub order: ClientOrderRequest,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ModifyRequest {
+    pub oid: u64,
+    pub order: OrderRequest,
+}


### PR DESCRIPTION
Allows modifying (replacing) an order

See https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/exchange-endpoint#modify-an-order
