### PR TITLE
Fix #64: ExchangeResponseStatus::Err now being returned as an Error

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -61,4 +61,7 @@ pub enum Error {
     SignatureFailure(String),
     #[error("Vault address not found")]
     VaultAddressNotFound,
+
+    #[error("ExchangeResponseStatus Error: {0:?}")]
+    ExchangeResponseStatusError(String),
 }

--- a/src/exchange/exchange_client.rs
+++ b/src/exchange/exchange_client.rs
@@ -139,14 +139,19 @@ impl ExchangeClient {
             .map_err(|e| Error::JsonParse(e.to_string()))?;
         debug!("Sending request {res:?}");
 
-        serde_json::from_str(
+        let response: ExchangeResponseStatus = serde_json::from_str(
             &self
                 .http_client
                 .post("/exchange", res)
                 .await
                 .map_err(|e| Error::JsonParse(e.to_string()))?,
         )
-        .map_err(|e| Error::JsonParse(e.to_string()))
+        .map_err(|e| Error::JsonParse(e.to_string()))?;
+
+        match response {
+            ExchangeResponseStatus::Err(s) => Err(Error::ExchangeResponseStatusError(s)),
+            val => Ok(val),
+        }
     }
 
     pub async fn usdc_transfer(


### PR DESCRIPTION
Wasn't sure if creating a new type was the right thing to do so I've added another variant to the Error enum for this specific error.

If a new type sounds better, do let me know.