### PR TITLE
Add Historical Orders to info client

### DIFF
--- a/src/bin/info.rs
+++ b/src/bin/info.rs
@@ -25,6 +25,7 @@ async fn main() {
     spot_meta_and_asset_contexts_example(&info_client).await;
     query_order_by_oid_example(&info_client).await;
     query_referral_state_example(&info_client).await;
+    historical_orders_example(&info_client).await;
 }
 
 fn address() -> H160 {
@@ -172,5 +173,13 @@ async fn query_referral_state_example(info_client: &InfoClient) {
     info!(
         "Referral state for {user}: {:?}",
         info_client.query_referral_state(user).await.unwrap()
+    );
+}
+
+async fn historical_orders_example(info_client: &InfoClient) {
+    let user = address();
+    info!(
+        "Historical orders for {user}: {:?}",
+        info_client.historical_orders(user).await.unwrap()
     );
 }

--- a/src/info/info_client.rs
+++ b/src/info/info_client.rs
@@ -1,7 +1,7 @@
 use crate::{
     info::{
         CandlesSnapshotResponse, FundingHistoryResponse, L2SnapshotResponse, OpenOrdersResponse,
-        RecentTradesResponse, UserFillsResponse, UserStateResponse,
+        OrderInfo, RecentTradesResponse, UserFillsResponse, UserStateResponse,
     },
     meta::{Meta, SpotMeta, SpotMetaAndAssetCtxs},
     prelude::*,
@@ -82,6 +82,9 @@ pub enum InfoRequest {
         req: CandleSnapshotRequest,
     },
     Referral {
+        user: H160,
+    },
+    HistoricalOrders {
         user: H160,
     },
 }
@@ -285,6 +288,11 @@ impl InfoClient {
 
     pub async fn query_referral_state(&self, address: H160) -> Result<ReferralResponse> {
         let input = InfoRequest::Referral { user: address };
+        self.send_info_request(input).await
+    }
+
+    pub async fn historical_orders(&self, address: H160) -> Result<Vec<OrderInfo>> {
+        let input = InfoRequest::HistoricalOrders { user: address };
         self.send_info_request(input).await
     }
 }


### PR DESCRIPTION
The API docs show a [method for retrieving historical orders](https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/info-endpoint#retrieve-a-users-historical-orders). The info client here doesn't otherwise allow for querying this endpoint, since `send_info_request` is private.

This PR adds a wrapper around `send_info_request` and adds it to the example `info.rs` file.