### PR TITLE
Add max leverage and cum funding to asset position

### DIFF
--- a/src/info/sub_structs.rs
+++ b/src/info/sub_structs.rs
@@ -12,6 +12,14 @@ pub struct Leverage {
 
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
+pub struct CumulativeFunding {
+    pub all_time: String,
+    pub since_open: String,
+    pub since_change: String,
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
 pub struct PositionData {
     pub coin: String,
     pub entry_px: Option<String>,
@@ -22,6 +30,8 @@ pub struct PositionData {
     pub return_on_equity: String,
     pub szi: String,
     pub unrealized_pnl: String,
+    pub max_leverage: u32,
+    pub cum_funding: CumulativeFunding,
 }
 
 #[derive(Deserialize, Debug)]


### PR DESCRIPTION
Added missing fields to `AssetPosition` struct:

- added `max_leverage: u32`
- added `cum_funding: CumulativeFunding`
 
```
interface CumulativeFunding {
    all_time: string,
    since_open: string,
    since_change: string,
}
```

Reference: https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/info-endpoint/perpetuals#retrieve-users-perpetuals-account-summary 