### PR TITLE
fixed usdc class transfers

### DIFF
--- a/src/bin/class_transfer.rs
+++ b/src/bin/class_transfer.rs
@@ -18,7 +18,7 @@ async fn main() {
     let to_perp = false;
 
     let res = exchange_client
-        .class_transfer(usdc, to_perp, None)
+        .usd_class_transfer(usdc, to_perp, None)
         .await
         .unwrap();
     info!("Class transfer result: {res:?}");


### PR DESCRIPTION
Using class transfer was broken, returning a JSON error indicating that the Hyperliquid server could not deserialize the Call.

This pull request corrects the issue by switching from the outdated Hyperliquid API call (L1 action) to properly using sign_typed_data, ensuring compatibility with the current Hyperliquid implementation and restoring proper transfer functionality.