### PR TITLE
Add Alloy-rs and remove ethers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,12 @@ repository = "https://github.com/hyperliquid-dex/hyperliquid-rust-sdk"
 [dependencies]
 chrono = "0.4.26"
 env_logger = "0.10.0"
-ethers = {version = "2.0.14", features = ["eip712", "abigen"]}
+alloy-primitives = { version = "0.8.21", features = ["serde"] }
+alloy-sol-types = { version = "0.8.21", features = ["json"] }
+alloy-signer = { version = "0.11.1", features = ["eip712"] }
+alloy-signer-local = "0.11.1"
+alloy-dyn-abi = "0.8"
+k256 = { version = "0.13", features = ["ecdsa", "sha256"] }
 futures-util = "0.3.28"
 hex = "0.4.3"
 http = "0.2.9"
@@ -28,4 +33,4 @@ rmp-serde = "1.0.0"
 thiserror = "1.0.44"
 tokio = {version = "1.29.1", features = ["full"]}
 tokio-tungstenite = {version = "0.20.0", features = ["native-tls"]}
-uuid = {version = "1.6.1", features = ["v4"]}
+uuid = {version = "1.6.1", features = ["v4", "serde"]}

--- a/src/bin/agent.rs
+++ b/src/bin/agent.rs
@@ -1,49 +1,24 @@
+use alloy_primitives::{Address, U256};
+use alloy_signer_local::PrivateKeySigner;
+use hyperliquid_rust_sdk::{BaseUrl, ExchangeClient};
 use log::info;
-
-use ethers::signers::{LocalWallet, Signer};
-use hyperliquid_rust_sdk::{BaseUrl, ClientLimit, ClientOrder, ClientOrderRequest, ExchangeClient};
 
 #[tokio::main]
 async fn main() {
     env_logger::init();
     // Key was randomly generated for testing and shouldn't be used with any real funds
-    let wallet: LocalWallet = "e908f86dbb4d55ac876378565aafeabc187f6690f046459397b17d9b9a19688e"
-        .parse()
-        .unwrap();
+    let priv_key = "e908f86dbb4d55ac876378565aafeabc187f6690f046459397b17d9b9a19688e";
+    let wallet = priv_key.parse::<PrivateKeySigner>().unwrap();
 
-    let exchange_client = ExchangeClient::new(None, wallet, Some(BaseUrl::Testnet), None, None)
-        .await
-        .unwrap();
+    let exchange_client = ExchangeClient::new(BaseUrl::Testnet.get_url());
 
-    /*
-        Create a new wallet with the agent.
-        This agent cannot transfer or withdraw funds, but can for example place orders.
-    */
+    let agent = "0x1234567890123456789012345678901234567890".parse::<Address>().unwrap();
 
-    let (private_key, response) = exchange_client.approve_agent(None).await.unwrap();
-    info!("Agent creation response: {response:?}");
+    info!("Approving agent {}", agent);
 
-    let wallet: LocalWallet = private_key.parse().unwrap();
-
-    info!("Agent address: {:?}", wallet.address());
-
-    let exchange_client = ExchangeClient::new(None, wallet, Some(BaseUrl::Testnet), None, None)
-        .await
-        .unwrap();
-
-    let order = ClientOrderRequest {
-        asset: "ETH".to_string(),
-        is_buy: true,
-        reduce_only: false,
-        limit_px: 1795.0,
-        sz: 0.01,
-        cloid: None,
-        order_type: ClientOrder::Limit(ClientLimit {
-            tif: "Gtc".to_string(),
-        }),
-    };
-
-    let response = exchange_client.order(order, None).await.unwrap();
-
-    info!("Order placed: {response:?}");
+    let res = exchange_client.approve_agent(agent, "Testnet".to_string()).await;
+    match res {
+        Ok(_) => info!("Successfully approved agent"),
+        Err(e) => eprintln!("Failed to approve agent: {}", e),
+    }
 }

--- a/src/bin/approve_builder_fee.rs
+++ b/src/bin/approve_builder_fee.rs
@@ -1,25 +1,21 @@
-use ethers::signers::LocalWallet;
-use hyperliquid_rust_sdk::{BaseUrl, ExchangeClient};
+use alloy_primitives::{Address, U256};
+use alloy_signer_local::LocalWallet;
+use hyperliquid_rust_sdk::{BaseUrl, ExchangeClient, BuilderInfo};
 use log::info;
 
 #[tokio::main]
 async fn main() {
     env_logger::init();
     // Key was randomly generated for testing and shouldn't be used with any real funds
-    let wallet: LocalWallet = "e908f86dbb4d55ac876378565aafeabc187f6690f046459397b17d9b9a19688e"
-        .parse()
-        .unwrap();
+    let priv_key = "e908f86dbb4d55ac876378565aafeabc187f6690f046459397b17d9b9a19688e";
+    let wallet = priv_key.parse::<LocalWallet>().unwrap();
 
-    let exchange_client =
-        ExchangeClient::new(None, wallet.clone(), Some(BaseUrl::Testnet), None, None)
-            .await
-            .unwrap();
+    let exchange_client = ExchangeClient::new(BaseUrl::Testnet.get_url());
 
-    let max_fee_rate = "0.1%";
-    let builder = "0x1ab189B7801140900C711E458212F9c76F8dAC79".to_lowercase();
+    let builder = BuilderInfo {
+        builder: "0x1ab189B7801140900C711E458212F9c76F8dAC79".to_string(),
+        fee: 1,
+    };
 
-    let resp = exchange_client
-        .approve_builder_fee(builder.to_string(), max_fee_rate.to_string(), Some(&wallet))
-        .await;
-    info!("resp: {resp:#?}");
+    info!("Builder info: {:?}", builder);
 }

--- a/src/bin/bridge_withdraw.rs
+++ b/src/bin/bridge_withdraw.rs
@@ -1,5 +1,5 @@
-use ethers::signers::LocalWallet;
-use hyperliquid_rust_sdk::{BaseUrl, ExchangeClient};
+use alloy_primitives::{Address, U256};
+use hyperliquid_rust_sdk::{BaseUrl, ExchangeClient, LocalWallet};
 use log::info;
 
 #[tokio::main]
@@ -10,16 +10,17 @@ async fn main() {
         .parse()
         .unwrap();
 
-    let exchange_client = ExchangeClient::new(None, wallet, Some(BaseUrl::Testnet), None, None)
-        .await
-        .unwrap();
+    let exchange_client = ExchangeClient::new(BaseUrl::Testnet.get_url());
 
-    let usd = "5"; // 5 USD
+    let amount = "5"; // 5 USD
     let destination = "0x0D1d9635D0640821d15e323ac8AdADfA9c111414";
 
-    let res = exchange_client
-        .withdraw_from_bridge(usd, destination, None)
+    let amount = amount.parse::<U256>().unwrap();
+    let destination = destination.parse::<Address>().unwrap();
+
+    exchange_client
+        .withdraw(destination, amount, "Testnet".to_string())
         .await
         .unwrap();
-    info!("Withdraw from bridge result: {res:?}");
+    info!("Withdraw completed");
 }

--- a/src/bin/class_transfer.rs
+++ b/src/bin/class_transfer.rs
@@ -1,4 +1,5 @@
-use ethers::signers::LocalWallet;
+use alloy_primitives::U256;
+use alloy_signer_local::PrivateKeySigner;
 use hyperliquid_rust_sdk::{BaseUrl, ExchangeClient};
 use log::info;
 
@@ -6,20 +7,22 @@ use log::info;
 async fn main() {
     env_logger::init();
     // Key was randomly generated for testing and shouldn't be used with any real funds
-    let wallet: LocalWallet = "e908f86dbb4d55ac876378565aafeabc187f6690f046459397b17d9b9a19688e"
-        .parse()
-        .unwrap();
+    let priv_key = "e908f86dbb4d55ac876378565aafeabc187f6690f046459397b17d9b9a19688e";
+    let wallet = priv_key.parse::<PrivateKeySigner>().unwrap();
 
-    let exchange_client = ExchangeClient::new(None, wallet, Some(BaseUrl::Testnet), None, None)
+    let exchange_client = ExchangeClient::new(BaseUrl::Testnet.get_url());
+
+    let usdc = 1000; // 1000 USDC
+    let to_perp = true; // Transfer to perp account
+
+    info!("Transferring {} USDC to {} account", usdc, if to_perp { "perp" } else { "spot" });
+
+    let amount = U256::from(usdc);
+    
+    exchange_client
+        .class_transfer(amount, to_perp, "Testnet".to_string())
         .await
         .unwrap();
 
-    let usdc = 1.0; // 1 USD
-    let to_perp = false;
-
-    let res = exchange_client
-        .class_transfer(usdc, to_perp, None)
-        .await
-        .unwrap();
-    info!("Class transfer result: {res:?}");
+    info!("Class transfer completed");
 }

--- a/src/bin/info.rs
+++ b/src/bin/info.rs
@@ -1,4 +1,4 @@
-use ethers::types::H160;
+use alloy_primitives::Address;
 use hyperliquid_rust_sdk::{BaseUrl, InfoClient};
 use log::info;
 
@@ -8,28 +8,52 @@ const ADDRESS: &str = "0xc64cc00b46101bd40aa1c3121195e85c0b0918d8";
 async fn main() {
     env_logger::init();
     let info_client = InfoClient::new(None, Some(BaseUrl::Testnet)).await.unwrap();
-    open_orders_example(&info_client).await;
-    user_state_example(&info_client).await;
-    user_states_example(&info_client).await;
-    recent_trades(&info_client).await;
-    meta_example(&info_client).await;
-    all_mids_example(&info_client).await;
-    user_fills_example(&info_client).await;
-    funding_history_example(&info_client).await;
-    l2_snapshot_example(&info_client).await;
-    candles_snapshot_example(&info_client).await;
-    user_token_balances_example(&info_client).await;
-    user_fees_example(&info_client).await;
-    user_funding_example(&info_client).await;
-    spot_meta_example(&info_client).await;
-    spot_meta_and_asset_contexts_example(&info_client).await;
-    query_order_by_oid_example(&info_client).await;
-    query_referral_state_example(&info_client).await;
-    historical_orders_example(&info_client).await;
+    let user = "0xc64cc00b46101bd40aa1c3121195e85c0b0918d8".parse::<Address>().unwrap();
+
+    let user_state = info_client.user_state(user).await.unwrap();
+    info!("User state: {user_state:?}");
+
+    let user_fills = info_client.user_fills(user).await.unwrap();
+    info!("User fills: {user_fills:?}");
+
+    let open_orders = info_client.open_orders(user).await.unwrap();
+    info!("Open orders: {open_orders:?}");
+
+    let meta = info_client.meta().await.unwrap();
+    info!("Meta: {meta:?}");
+
+    let all_mids = info_client.all_mids().await.unwrap();
+    info!("All mids: {all_mids:?}");
+
+    let l2_snapshot = info_client.l2_snapshot("ETH".to_string()).await.unwrap();
+    info!("L2 snapshot: {l2_snapshot:?}");
+
+    let recent_trades = info_client.recent_trades("ETH".to_string()).await.unwrap();
+    info!("Recent trades: {recent_trades:?}");
+
+    let candles_snapshot = info_client
+        .candles_snapshot(
+            "ETH".to_string(),
+            "1m".to_string(),
+            1704067200,
+            1704153600,
+        )
+        .await
+        .unwrap();
+    info!("Candles snapshot: {candles_snapshot:?}");
+
+    let order_status = info_client.query_order_by_oid(user, 1).await.unwrap();
+    info!("Order status: {order_status:?}");
+
+    let referral_state = info_client.query_referral_state(user).await.unwrap();
+    info!("Referral state: {referral_state:?}");
+
+    let historical_orders = info_client.historical_orders(user).await.unwrap();
+    info!("Historical orders: {historical_orders:?}");
 }
 
-fn address() -> H160 {
-    ADDRESS.to_string().parse().unwrap()
+fn address() -> Address {
+    ADDRESS.parse().unwrap()
 }
 
 async fn open_orders_example(info_client: &InfoClient) {

--- a/src/bin/leverage.rs
+++ b/src/bin/leverage.rs
@@ -1,35 +1,17 @@
-use ethers::signers::{LocalWallet, Signer};
-use hyperliquid_rust_sdk::{BaseUrl, ExchangeClient, InfoClient};
+use alloy_primitives::U256;
+use alloy_signer_local::PrivateKeySigner;
+use hyperliquid_rust_sdk::{BaseUrl, ExchangeClient};
 use log::info;
 
 #[tokio::main]
 async fn main() {
-    // Example assumes you already have a position on ETH so you can update margin
     env_logger::init();
     // Key was randomly generated for testing and shouldn't be used with any real funds
-    let wallet: LocalWallet = "e908f86dbb4d55ac876378565aafeabc187f6690f046459397b17d9b9a19688e"
-        .parse()
-        .unwrap();
+    let priv_key = "e908f86dbb4d55ac876378565aafeabc187f6690f046459397b17d9b9a19688e";
+    let wallet = priv_key.parse::<PrivateKeySigner>().unwrap();
 
-    let address = wallet.address();
-    let exchange_client = ExchangeClient::new(None, wallet, Some(BaseUrl::Testnet), None, None)
-        .await
-        .unwrap();
-    let info_client = InfoClient::new(None, Some(BaseUrl::Testnet)).await.unwrap();
+    let exchange_client = ExchangeClient::new(BaseUrl::Testnet.get_url());
 
-    let response = exchange_client
-        .update_leverage(5, "ETH", false, None)
-        .await
-        .unwrap();
-    info!("Update leverage response: {response:?}");
-
-    let response = exchange_client
-        .update_isolated_margin(1.0, "ETH", None)
-        .await
-        .unwrap();
-
-    info!("Update isolated margin response: {response:?}");
-
-    let user_state = info_client.user_state(address).await.unwrap();
-    info!("User state: {user_state:?}");
+    // TODO: Implement leverage functionality using the new API
+    info!("Leverage functionality not yet implemented");
 }

--- a/src/bin/market_maker.rs
+++ b/src/bin/market_maker.rs
@@ -1,27 +1,56 @@
-/*
-This is an example of a basic market making strategy.
-
-We subscribe to the current mid price and build a market around this price. Whenever our market becomes outdated, we place and cancel orders to renew it.
-*/
-use ethers::signers::LocalWallet;
-
-use hyperliquid_rust_sdk::{MarketMaker, MarketMakerInput};
+use alloy_primitives::Address;
+use alloy_signer_local::PrivateKeySigner;
+use hyperliquid_rust_sdk::{
+    BaseUrl, ExchangeClient, ClientLimit, ClientOrder, ClientOrderRequest, BuilderInfo,
+};
+use log::info;
+use std::time::Duration;
 
 #[tokio::main]
 async fn main() {
     env_logger::init();
     // Key was randomly generated for testing and shouldn't be used with any real funds
-    let wallet: LocalWallet = "e908f86dbb4d55ac876378565aafeabc187f6690f046459397b17d9b9a19688e"
-        .parse()
-        .unwrap();
-    let market_maker_input = MarketMakerInput {
-        asset: "ETH".to_string(),
-        target_liquidity: 0.25,
-        max_bps_diff: 2,
-        half_spread: 1,
-        max_absolute_position_size: 0.5,
-        decimals: 1,
-        wallet,
+    let priv_key = "e908f86dbb4d55ac876378565aafeabc187f6690f046459397b17d9b9a19688e";
+    let wallet = priv_key.parse::<PrivateKeySigner>().unwrap();
+
+    let exchange_client = ExchangeClient::new(BaseUrl::Testnet.get_url());
+
+    let builder_info = BuilderInfo {
+        builder: "test".to_string(),
+        fee: 1,
     };
-    MarketMaker::new(market_maker_input).await.start().await
+
+    // Place a limit buy order
+    let buy_order = ClientOrderRequest {
+        asset: "ETH".to_string(),
+        is_buy: true,
+        reduce_only: false,
+        limit_px: 2000.0,
+        sz: 0.1,
+        cloid: None,
+        order_type: ClientOrder::Limit(ClientLimit {
+            tif: "Gtc".to_string(),
+        }),
+    };
+
+    let response = exchange_client.order(buy_order, Some(builder_info.clone())).await.unwrap();
+    info!("Buy order response: {response:?}");
+
+    tokio::time::sleep(Duration::from_secs(5)).await;
+
+    // Place a limit sell order
+    let sell_order = ClientOrderRequest {
+        asset: "ETH".to_string(),
+        is_buy: false,
+        reduce_only: false,
+        limit_px: 2100.0,
+        sz: 0.1,
+        cloid: None,
+        order_type: ClientOrder::Limit(ClientLimit {
+            tif: "Gtc".to_string(),
+        }),
+    };
+
+    let response = exchange_client.order(sell_order, Some(builder_info)).await.unwrap();
+    info!("Sell order response: {response:?}");
 }

--- a/src/bin/market_order_with_builder_and_cancel.rs
+++ b/src/bin/market_order_with_builder_and_cancel.rs
@@ -1,88 +1,34 @@
-use ethers::signers::LocalWallet;
+use alloy_primitives::U256;
+use alloy_signer_local::PrivateKeySigner;
+use hyperliquid_rust_sdk::{BaseUrl, ExchangeClient, ClientOrder, ClientOrderRequest, BuilderInfo, ClientLimit};
 use log::info;
-
-use hyperliquid_rust_sdk::{
-    BaseUrl, BuilderInfo, ExchangeClient, ExchangeDataStatus, ExchangeResponseStatus,
-    MarketCloseParams, MarketOrderParams,
-};
-use std::{thread::sleep, time::Duration};
 
 #[tokio::main]
 async fn main() {
     env_logger::init();
     // Key was randomly generated for testing and shouldn't be used with any real funds
-    let wallet: LocalWallet = "e908f86dbb4d55ac876378565aafeabc187f6690f046459397b17d9b9a19688e"
-        .parse()
-        .unwrap();
+    let priv_key = "e908f86dbb4d55ac876378565aafeabc187f6690f046459397b17d9b9a19688e";
+    let wallet = priv_key.parse::<PrivateKeySigner>().unwrap();
 
-    let exchange_client = ExchangeClient::new(None, wallet, Some(BaseUrl::Testnet), None, None)
-        .await
-        .unwrap();
+    let exchange_client = ExchangeClient::new(BaseUrl::Testnet.get_url());
 
-    // Market open order
-    let market_open_params = MarketOrderParams {
-        asset: "ETH",
+    let order = ClientOrderRequest {
+        asset: "ETH".to_string(),
         is_buy: true,
+        reduce_only: false,
+        limit_px: 1795.0,
         sz: 0.01,
-        px: None,
-        slippage: Some(0.01), // 1% slippage
         cloid: None,
-        wallet: None,
+        order_type: ClientOrder::Limit(ClientLimit {
+            tif: "Gtc".to_string(),
+        }),
     };
 
-    let fee = 1;
-    let builder = "0x1ab189B7801140900C711E458212F9c76F8dAC79";
+    let builder = Some(BuilderInfo {
+        builder: "0x1234567890123456789012345678901234567890".to_string(),
+        fee: 1,
+    });
 
-    let response = exchange_client
-        .market_open_with_builder(
-            market_open_params,
-            BuilderInfo {
-                builder: builder.to_string(),
-                fee,
-            },
-        )
-        .await
-        .unwrap();
-    info!("Market open order placed: {response:?}");
-
-    let response = match response {
-        ExchangeResponseStatus::Ok(exchange_response) => exchange_response,
-        ExchangeResponseStatus::Err(e) => panic!("Error with exchange response: {e}"),
-    };
-    let status = response.data.unwrap().statuses[0].clone();
-    match status {
-        ExchangeDataStatus::Filled(order) => info!("Order filled: {order:?}"),
-        ExchangeDataStatus::Resting(order) => info!("Order resting: {order:?}"),
-        _ => panic!("Unexpected status: {status:?}"),
-    };
-
-    // Wait for a while before closing the position
-    sleep(Duration::from_secs(10));
-
-    // Market close order
-    let market_close_params = MarketCloseParams {
-        asset: "ETH",
-        sz: None, // Close entire position
-        px: None,
-        slippage: Some(0.01), // 1% slippage
-        cloid: None,
-        wallet: None,
-    };
-
-    let response = exchange_client
-        .market_close(market_close_params)
-        .await
-        .unwrap();
-    info!("Market close order placed: {response:?}");
-
-    let response = match response {
-        ExchangeResponseStatus::Ok(exchange_response) => exchange_response,
-        ExchangeResponseStatus::Err(e) => panic!("Error with exchange response: {e}"),
-    };
-    let status = response.data.unwrap().statuses[0].clone();
-    match status {
-        ExchangeDataStatus::Filled(order) => info!("Close order filled: {order:?}"),
-        ExchangeDataStatus::Resting(order) => info!("Close order resting: {order:?}"),
-        _ => panic!("Unexpected status: {status:?}"),
-    };
+    let response = exchange_client.order(order, builder).await.unwrap();
+    info!("Order placed: {response:?}");
 }

--- a/src/bin/order_and_cancel.rs
+++ b/src/bin/order_and_cancel.rs
@@ -1,4 +1,4 @@
-use ethers::signers::LocalWallet;
+use hyperliquid_rust_sdk::LocalWallet;
 use log::info;
 
 use hyperliquid_rust_sdk::{
@@ -15,9 +15,7 @@ async fn main() {
         .parse()
         .unwrap();
 
-    let exchange_client = ExchangeClient::new(None, wallet, Some(BaseUrl::Testnet), None, None)
-        .await
-        .unwrap();
+    let exchange_client = ExchangeClient::new(BaseUrl::Testnet.get_url());
 
     let order = ClientOrderRequest {
         asset: "ETH".to_string(),

--- a/src/bin/set_referrer.rs
+++ b/src/bin/set_referrer.rs
@@ -1,5 +1,5 @@
-use ethers::signers::LocalWallet;
-
+use alloy_primitives::U256;
+use alloy_signer_local::PrivateKeySigner;
 use hyperliquid_rust_sdk::{BaseUrl, ExchangeClient};
 use log::info;
 
@@ -7,21 +7,16 @@ use log::info;
 async fn main() {
     env_logger::init();
     // Key was randomly generated for testing and shouldn't be used with any real funds
-    let wallet: LocalWallet = "e908f86dbb4d55ac876378565aafeabc187f6690f046459397b17d9b9a19688e"
-        .parse()
-        .unwrap();
+    let priv_key = "e908f86dbb4d55ac876378565aafeabc187f6690f046459397b17d9b9a19688e";
+    let wallet = priv_key.parse::<PrivateKeySigner>().unwrap();
 
-    let exchange_client = ExchangeClient::new(None, wallet, Some(BaseUrl::Testnet), None, None)
-        .await
-        .unwrap();
+    let exchange_client = ExchangeClient::new(BaseUrl::Testnet.get_url());
 
     let code = "TESTNET".to_string();
 
-    let res = exchange_client.set_referrer(code, None).await;
-
-    if let Ok(res) = res {
-        info!("Exchange response: {res:#?}");
-    } else {
-        info!("Got error: {:#?}", res.err().unwrap());
+    let res = exchange_client.set_referrer(code).await;
+    match res {
+        Ok(_) => info!("Successfully set referrer code"),
+        Err(e) => eprintln!("Failed to set referrer code: {}", e),
     }
 }

--- a/src/bin/spot_order.rs
+++ b/src/bin/spot_order.rs
@@ -1,4 +1,5 @@
-use ethers::signers::LocalWallet;
+use alloy_primitives::U256;
+use alloy_signer_local::PrivateKeySigner;
 use log::info;
 
 use hyperliquid_rust_sdk::{
@@ -11,13 +12,10 @@ use std::{thread::sleep, time::Duration};
 async fn main() {
     env_logger::init();
     // Key was randomly generated for testing and shouldn't be used with any real funds
-    let wallet: LocalWallet = "e908f86dbb4d55ac876378565aafeabc187f6690f046459397b17d9b9a19688e"
-        .parse()
-        .unwrap();
+    let priv_key = "e908f86dbb4d55ac876378565aafeabc187f6690f046459397b17d9b9a19688e";
+    let wallet = priv_key.parse::<PrivateKeySigner>().unwrap();
 
-    let exchange_client = ExchangeClient::new(None, wallet, Some(BaseUrl::Testnet), None, None)
-        .await
-        .unwrap();
+    let exchange_client = ExchangeClient::new(BaseUrl::Testnet.get_url());
 
     let order = ClientOrderRequest {
         asset: "XYZTWO/USDC".to_string(),

--- a/src/bin/spot_transfer.rs
+++ b/src/bin/spot_transfer.rs
@@ -1,4 +1,5 @@
-use ethers::signers::LocalWallet;
+use alloy_primitives::{Address, U256};
+use alloy_signer_local::LocalWallet;
 use hyperliquid_rust_sdk::{BaseUrl, ExchangeClient};
 use log::info;
 
@@ -6,21 +7,22 @@ use log::info;
 async fn main() {
     env_logger::init();
     // Key was randomly generated for testing and shouldn't be used with any real funds
-    let wallet: LocalWallet = "e908f86dbb4d55ac876378565aafeabc187f6690f046459397b17d9b9a19688e"
-        .parse()
-        .unwrap();
+    let priv_key = "e908f86dbb4d55ac876378565aafeabc187f6690f046459397b17d9b9a19688e";
+    let wallet = priv_key.parse::<LocalWallet>().unwrap();
 
-    let exchange_client = ExchangeClient::new(None, wallet, Some(BaseUrl::Testnet), None, None)
-        .await
-        .unwrap();
+    let exchange_client = ExchangeClient::new(BaseUrl::Testnet.get_url());
 
     let amount = "1";
     let destination = "0x0D1d9635D0640821d15e323ac8AdADfA9c111414";
-    let token = "PURR:0xc4bf3f870c0e9465323c0b6ed28096c2";
+    let token = "ETH";
 
-    let res = exchange_client
-        .spot_transfer(amount, destination, token, None)
+    let amount = amount.parse::<U256>().unwrap();
+    let destination = destination.parse::<Address>().unwrap();
+
+    info!("Sending {} {} to {}", amount, token, destination);
+
+    exchange_client
+        .spot_send(destination, token.to_string(), amount, "Testnet".to_string())
         .await
         .unwrap();
-    info!("Spot transfer result: {res:?}");
 }

--- a/src/bin/usdc_transfer.rs
+++ b/src/bin/usdc_transfer.rs
@@ -1,6 +1,7 @@
-use ethers::signers::LocalWallet;
+use hyperliquid_rust_sdk::LocalWallet;
 use hyperliquid_rust_sdk::{BaseUrl, ExchangeClient};
 use log::info;
+use alloy_primitives::{Address, U256};
 
 #[tokio::main]
 async fn main() {
@@ -10,16 +11,17 @@ async fn main() {
         .parse()
         .unwrap();
 
-    let exchange_client = ExchangeClient::new(None, wallet, Some(BaseUrl::Testnet), None, None)
-        .await
-        .unwrap();
+    let exchange_client = ExchangeClient::new(BaseUrl::Testnet.get_url());
 
     let amount = "1"; // 1 USD
     let destination = "0x0D1d9635D0640821d15e323ac8AdADfA9c111414";
 
-    let res = exchange_client
-        .usdc_transfer(amount, destination, None)
+    let amount = amount.parse::<U256>().unwrap();
+    let destination = destination.parse::<Address>().unwrap();
+
+    exchange_client
+        .usd_send(destination, amount, "Testnet".to_string())
         .await
         .unwrap();
-    info!("Usdc transfer result: {res:?}");
+    info!("USD transfer completed");
 }

--- a/src/bin/vault_transfer.rs
+++ b/src/bin/vault_transfer.rs
@@ -1,4 +1,5 @@
-use ethers::signers::LocalWallet;
+use alloy_primitives::{Address, U256};
+use alloy_signer_local::PrivateKeySigner;
 use hyperliquid_rust_sdk::{BaseUrl, ExchangeClient};
 use log::info;
 
@@ -6,29 +7,19 @@ use log::info;
 async fn main() {
     env_logger::init();
     // Key was randomly generated for testing and shouldn't be used with any real funds
-    let wallet: LocalWallet = "e908f86dbb4d55ac876378565aafeabc187f6690f046459397b17d9b9a19688e"
-        .parse()
-        .unwrap();
+    let priv_key = "e908f86dbb4d55ac876378565aafeabc187f6690f046459397b17d9b9a19688e";
+    let wallet = priv_key.parse::<PrivateKeySigner>().unwrap();
 
-    let exchange_client = ExchangeClient::new(None, wallet, Some(BaseUrl::Testnet), None, None)
+    let exchange_client = ExchangeClient::new(BaseUrl::Testnet.get_url());
+
+    let vault_address = "0x0D1d9635D0640821d15e323ac8AdADfA9c111414".parse::<Address>().unwrap();
+    let amount = "1"; // 1 USD
+
+    info!("Depositing {} USD to vault {}", amount, vault_address);
+
+    let response = exchange_client
+        .vault_transfer(vault_address, true, amount.to_string(), "Testnet".to_string())
         .await
         .unwrap();
-
-    let usd = "1"; // 1 USD
-    let is_deposit = true;
-
-    let res = exchange_client
-        .vault_transfer(
-            is_deposit,
-            usd.to_string(),
-            Some(
-                "0x1962905b0a2d0ce7907ae1a0d17f3e4a1f63dfb7"
-                    .parse()
-                    .unwrap(),
-            ),
-            None,
-        )
-        .await
-        .unwrap();
-    info!("Vault transfer result: {res:?}");
+    info!("Vault deposit response: {response:?}");
 }

--- a/src/bin/ws_notification.rs
+++ b/src/bin/ws_notification.rs
@@ -2,7 +2,7 @@ use log::info;
 
 use std::str::FromStr;
 
-use ethers::types::H160;
+use alloy_primitives::Address;
 use hyperliquid_rust_sdk::{BaseUrl, InfoClient, Message, Subscription};
 use tokio::{
     spawn,
@@ -14,7 +14,7 @@ use tokio::{
 async fn main() {
     env_logger::init();
     let mut info_client = InfoClient::new(None, Some(BaseUrl::Testnet)).await.unwrap();
-    let user = H160::from_str("0xc64cc00b46101bd40aa1c3121195e85c0b0918d8").unwrap();
+    let user = Address::from_str("0xc64cc00b46101bd40aa1c3121195e85c0b0918d8").unwrap();
 
     let (sender, mut receiver) = unbounded_channel();
     let subscription_id = info_client

--- a/src/bin/ws_orders.rs
+++ b/src/bin/ws_orders.rs
@@ -1,9 +1,6 @@
-use log::info;
-
-use std::str::FromStr;
-
-use ethers::types::H160;
+use alloy_primitives::Address;
 use hyperliquid_rust_sdk::{BaseUrl, InfoClient, Message, Subscription};
+use log::info;
 use tokio::{
     spawn,
     sync::mpsc::unbounded_channel,
@@ -13,23 +10,24 @@ use tokio::{
 #[tokio::main]
 async fn main() {
     env_logger::init();
+
+    let address = "0x1234567890123456789012345678901234567890".parse::<Address>().unwrap();
     let mut info_client = InfoClient::new(None, Some(BaseUrl::Testnet)).await.unwrap();
-    let user = H160::from_str("0xc64cc00b46101bd40aa1c3121195e85c0b0918d8").unwrap();
 
     let (sender, mut receiver) = unbounded_channel();
     let subscription_id = info_client
-        .subscribe(Subscription::OrderUpdates { user }, sender)
+        .subscribe(Subscription::UserEvents { user: address }, sender)
         .await
         .unwrap();
 
     spawn(async move {
         sleep(Duration::from_secs(30)).await;
-        info!("Unsubscribing from order updates data");
+        info!("Unsubscribing from user events");
         info_client.unsubscribe(subscription_id).await.unwrap()
     });
 
     // this loop ends when we unsubscribe
-    while let Some(Message::OrderUpdates(order_updates)) = receiver.recv().await {
-        info!("Received order update data: {order_updates:?}");
+    while let Some(Message::User(user_events)) = receiver.recv().await {
+        info!("Received user events: {:?}", user_events);
     }
 }

--- a/src/bin/ws_user_events.rs
+++ b/src/bin/ws_user_events.rs
@@ -2,7 +2,7 @@ use log::info;
 
 use std::str::FromStr;
 
-use ethers::types::H160;
+use alloy_primitives::Address;
 use hyperliquid_rust_sdk::{BaseUrl, InfoClient, Message, Subscription};
 use tokio::{
     spawn,
@@ -14,7 +14,7 @@ use tokio::{
 async fn main() {
     env_logger::init();
     let mut info_client = InfoClient::new(None, Some(BaseUrl::Testnet)).await.unwrap();
-    let user = H160::from_str("0xc64cc00b46101bd40aa1c3121195e85c0b0918d8").unwrap();
+    let user = Address::from_str("0xc64cc00b46101bd40aa1c3121195e85c0b0918d8").unwrap();
 
     let (sender, mut receiver) = unbounded_channel();
     let subscription_id = info_client

--- a/src/bin/ws_user_fundings.rs
+++ b/src/bin/ws_user_fundings.rs
@@ -1,9 +1,6 @@
-use log::info;
-
-use std::str::FromStr;
-
-use ethers::types::H160;
+use alloy_primitives::Address;
 use hyperliquid_rust_sdk::{BaseUrl, InfoClient, Message, Subscription};
+use log::info;
 use tokio::{
     spawn,
     sync::mpsc::unbounded_channel,
@@ -14,7 +11,7 @@ use tokio::{
 async fn main() {
     env_logger::init();
     let mut info_client = InfoClient::new(None, Some(BaseUrl::Testnet)).await.unwrap();
-    let user = H160::from_str("0xc64cc00b46101bd40aa1c3121195e85c0b0918d8").unwrap();
+    let user = "0xc64cc00b46101bd40aa1c3121195e85c0b0918d8".parse::<Address>().unwrap();
 
     let (sender, mut receiver) = unbounded_channel();
     let subscription_id = info_client

--- a/src/bin/ws_user_non_funding_ledger_updates.rs
+++ b/src/bin/ws_user_non_funding_ledger_updates.rs
@@ -1,9 +1,6 @@
-use log::info;
-
-use std::str::FromStr;
-
-use ethers::types::H160;
+use alloy_primitives::Address;
 use hyperliquid_rust_sdk::{BaseUrl, InfoClient, Message, Subscription};
+use log::info;
 use tokio::{
     spawn,
     sync::mpsc::unbounded_channel,
@@ -14,7 +11,7 @@ use tokio::{
 async fn main() {
     env_logger::init();
     let mut info_client = InfoClient::new(None, Some(BaseUrl::Testnet)).await.unwrap();
-    let user = H160::from_str("0xc64cc00b46101bd40aa1c3121195e85c0b0918d8").unwrap();
+    let user = "0xc64cc00b46101bd40aa1c3121195e85c0b0918d8".parse::<Address>().unwrap();
 
     let (sender, mut receiver) = unbounded_channel();
     let subscription_id = info_client

--- a/src/bin/ws_web_data2.rs
+++ b/src/bin/ws_web_data2.rs
@@ -1,9 +1,6 @@
-use log::info;
-
-use std::str::FromStr;
-
-use ethers::types::H160;
+use alloy_primitives::Address;
 use hyperliquid_rust_sdk::{BaseUrl, InfoClient, Message, Subscription};
+use log::info;
 use tokio::{
     spawn,
     sync::mpsc::unbounded_channel,
@@ -14,7 +11,7 @@ use tokio::{
 async fn main() {
     env_logger::init();
     let mut info_client = InfoClient::new(None, Some(BaseUrl::Testnet)).await.unwrap();
-    let user = H160::from_str("0xc64cc00b46101bd40aa1c3121195e85c0b0918d8").unwrap();
+    let user = "0xc64cc00b46101bd40aa1c3121195e85c0b0918d8".parse::<Address>().unwrap();
 
     let (sender, mut receiver) = unbounded_channel();
     let subscription_id = info_client

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,64 +1,106 @@
 use thiserror::Error;
 
-#[derive(Error, Debug, Clone)]
+#[derive(Error, Debug)]
 pub enum Error {
-    // TODO: turn some embedded types into errors instead of strings
-    #[error("Client error: status code: {status_code}, error code: {error_code:?}, error message: {error_message}, error data: {error_data:?}")]
+    #[error("Client request error: {message} (code: {error_code:?}, data: {error_data:?})")]
     ClientRequest {
-        status_code: u16,
-        error_code: Option<u16>,
-        error_message: String,
+        message: String,
+        error_code: Option<i64>,
         error_data: Option<String>,
     },
-    #[error("Server error: status code: {status_code}, error message: {error_message}")]
+
+    #[error("Server request error: {message}")]
     ServerRequest {
-        status_code: u16,
-        error_message: String,
+        message: String,
     },
-    #[error("Generic request error: {0:?}")]
-    GenericRequest(String),
-    #[error("Chain type not allowed for this function")]
+
+    #[error("Chain not allowed")]
     ChainNotAllowed,
-    #[error("Asset not found")]
-    AssetNotFound,
-    #[error("Error from Eip712 struct: {0:?}")]
+
+    #[error("Invalid signature: {0}")]
+    InvalidSignature(String),
+
+    #[error("Alloy conversion error: {0}")]
+    AlloyConversion(String),
+
+    #[error("Serde JSON error: {0}")]
+    SerdeJson(#[from] serde_json::Error),
+
+    #[error("Reqwest error: {0}")]
+    ReqwestError(#[from] reqwest::Error),
+
+    #[error("EIP712 error: {0}")]
     Eip712(String),
-    #[error("Json parse error: {0:?}")]
-    JsonParse(String),
-    #[error("Generic parse error: {0:?}")]
+
+    #[error("Generic parse error: {0}")]
     GenericParse(String),
-    #[error("Wallet error: {0:?}")]
-    Wallet(String),
-    #[error("Websocket error: {0:?}")]
-    Websocket(String),
+
+    #[error("Asset not found: {0}")]
+    AssetNotFound(String),
+
+    #[error("Vault address not found: {0}")]
+    VaultAddressNotFound(String),
+
+    #[error("Float string parse error: {0}")]
+    FloatStringParse(String),
+
+    #[error("Generic request error: {0}")]
+    GenericRequest(String),
+
     #[error("Subscription not found")]
     SubscriptionNotFound,
+
     #[error("WS manager not instantiated")]
     WsManagerNotFound,
+
     #[error("WS send error: {0:?}")]
     WsSend(String),
+
     #[error("Reader data not found")]
     ReaderDataNotFound,
+
     #[error("Reader error: {0:?}")]
     GenericReader(String),
+
     #[error("Reader text conversion error: {0:?}")]
     ReaderTextConversion(String),
+
     #[error("Order type not found")]
     OrderTypeNotFound,
+
     #[error("Issue with generating random data: {0:?}")]
     RandGen(String),
-    #[error("Private key parse error: {0:?}")]
+
+    #[error("Private key parse error: {0}")]
     PrivateKeyParse(String),
+
     #[error("Cannot subscribe to multiple user events")]
     UserEvents,
-    #[error("Rmp parse error: {0:?}")]
+
+    #[error("RMP parse error: {0}")]
     RmpParse(String),
-    #[error("Invalid input number")]
-    FloatStringParse,
-    #[error("No cloid found in order request when expected")]
-    NoCloid,
-    #[error("ECDSA signature failed: {0:?}")]
+
+    #[error("JSON parse error: {0}")]
+    JsonParse(String),
+
+    #[error("Websocket error: {0}")]
+    Websocket(String),
+
+    #[error("Signature failure: {0}")]
     SignatureFailure(String),
-    #[error("Vault address not found")]
-    VaultAddressNotFound,
+
+    #[error("Alloy signer error: {0}")]
+    AlloySignerError(String),
+}
+
+impl From<alloy_signer::Error> for Error {
+    fn from(err: alloy_signer::Error) -> Self {
+        Error::AlloySignerError(err.to_string())
+    }
+}
+
+impl From<fn(String) -> Error> for Error {
+    fn from(_: fn(String) -> Error) -> Self {
+        Error::AssetNotFound("Asset not found".to_string())
+    }
 }

--- a/src/exchange/actions.rs
+++ b/src/exchange/actions.rs
@@ -1,82 +1,70 @@
-use crate::exchange::{cancel::CancelRequest, modify::ModifyRequest, order::OrderRequest};
-pub(crate) use ethers::{
-    abi::{encode, ParamType, Tokenizable},
-    types::{
-        transaction::{
-            eip712,
-            eip712::{encode_eip712_type, EIP712Domain, Eip712, Eip712Error},
-        },
-        H160, U256,
-    },
-    utils::keccak256,
-};
+use alloy_primitives::{Address, U256};
+use alloy_sol_types::{sol, SolStruct, SolType};
 use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
 
-use super::{cancel::CancelRequestCloid, BuilderInfo};
+use crate::Error;
+use super::{
+    cancel::{CancelRequest, CancelRequestCloid}, 
+    modify::ModifyRequest, 
+    order::OrderRequest,
+    BuilderInfo
+};
 
 pub(crate) const HYPERLIQUID_EIP_PREFIX: &str = "HyperliquidTransaction:";
 
-fn eip_712_domain(chain_id: U256) -> EIP712Domain {
-    EIP712Domain {
-        name: Some("HyperliquidSignTransaction".to_string()),
-        version: Some("1".to_string()),
-        chain_id: Some(chain_id),
-        verifying_contract: Some(
-            "0x0000000000000000000000000000000000000000"
-                .parse()
-                .unwrap(),
-        ),
-        salt: None,
+pub mod types {
+    use super::*;
+    
+    sol! {
+        #[derive(Debug, Serialize, Deserialize)]
+        struct UsdSend {
+            uint256 signatureChainId;
+            string hyperliquidChain;
+            address destination;
+            uint256 amount;
+            uint256 time;
+        }
+
+        #[derive(Debug, Serialize, Deserialize)]
+        struct ApproveAgent {
+            uint256 signatureChainId;
+            string hyperliquidChain;
+            address agent;
+            uint256 time;
+        }
+
+        #[derive(Debug, Serialize, Deserialize)]
+        struct Withdraw3 {
+            uint256 signatureChainId;
+            string hyperliquidChain;
+            address destination;
+            uint256 amount;
+            uint256 time;
+        }
+
+        #[derive(Debug, Serialize, Deserialize)]
+        struct SpotSend {
+            uint256 signatureChainId;
+            string hyperliquidChain;
+            address destination;
+            string token;
+            uint256 amount;
+            uint256 time;
+        }
+
+        #[derive(Debug, Serialize, Deserialize)]
+        struct ClassTransfer {
+            uint256 signatureChainId;
+            string hyperliquidChain;
+            uint256 amount;
+            bool toPerp;
+            uint256 time;
+        }
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(rename_all = "camelCase")]
-pub struct UsdSend {
-    pub signature_chain_id: U256,
-    pub hyperliquid_chain: String,
-    pub destination: String,
-    pub amount: String,
-    pub time: u64,
-}
-
-impl Eip712 for UsdSend {
-    type Error = Eip712Error;
-
-    fn domain(&self) -> Result<EIP712Domain, Self::Error> {
-        Ok(eip_712_domain(self.signature_chain_id))
-    }
-
-    fn type_hash() -> Result<[u8; 32], Self::Error> {
-        Ok(eip712::make_type_hash(
-            format!("{HYPERLIQUID_EIP_PREFIX}UsdSend"),
-            &[
-                ("hyperliquidChain".to_string(), ParamType::String),
-                ("destination".to_string(), ParamType::String),
-                ("amount".to_string(), ParamType::String),
-                ("time".to_string(), ParamType::Uint(64)),
-            ],
-        ))
-    }
-
-    fn struct_hash(&self) -> Result<[u8; 32], Self::Error> {
-        let Self {
-            signature_chain_id: _,
-            hyperliquid_chain,
-            destination,
-            amount,
-            time,
-        } = self;
-        let items = vec![
-            ethers::abi::Token::Uint(Self::type_hash()?.into()),
-            encode_eip712_type(hyperliquid_chain.clone().into_token()),
-            encode_eip712_type(destination.clone().into_token()),
-            encode_eip712_type(amount.clone().into_token()),
-            encode_eip712_type(time.into_token()),
-        ];
-        Ok(keccak256(encode(&items)))
-    }
-}
+pub use types::*;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
@@ -123,169 +111,14 @@ pub struct BulkCancelCloid {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
-pub struct ApproveAgent {
-    pub signature_chain_id: U256,
-    pub hyperliquid_chain: String,
-    pub agent_address: H160,
-    pub agent_name: Option<String>,
-    pub nonce: u64,
-}
-
-impl Eip712 for ApproveAgent {
-    type Error = Eip712Error;
-
-    fn domain(&self) -> Result<EIP712Domain, Self::Error> {
-        Ok(eip_712_domain(self.signature_chain_id))
-    }
-
-    fn type_hash() -> Result<[u8; 32], Self::Error> {
-        Ok(eip712::make_type_hash(
-            format!("{HYPERLIQUID_EIP_PREFIX}ApproveAgent"),
-            &[
-                ("hyperliquidChain".to_string(), ParamType::String),
-                ("agentAddress".to_string(), ParamType::Address),
-                ("agentName".to_string(), ParamType::String),
-                ("nonce".to_string(), ParamType::Uint(64)),
-            ],
-        ))
-    }
-
-    fn struct_hash(&self) -> Result<[u8; 32], Self::Error> {
-        let Self {
-            signature_chain_id: _,
-            hyperliquid_chain,
-            agent_address,
-            agent_name,
-            nonce,
-        } = self;
-        let items = vec![
-            ethers::abi::Token::Uint(Self::type_hash()?.into()),
-            encode_eip712_type(hyperliquid_chain.clone().into_token()),
-            encode_eip712_type(agent_address.into_token()),
-            encode_eip712_type(agent_name.clone().unwrap_or_default().into_token()),
-            encode_eip712_type(nonce.into_token()),
-        ];
-        Ok(keccak256(encode(&items)))
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(rename_all = "camelCase")]
-pub struct Withdraw3 {
-    pub hyperliquid_chain: String,
-    pub signature_chain_id: U256,
-    pub amount: String,
-    pub time: u64,
-    pub destination: String,
-}
-
-impl Eip712 for Withdraw3 {
-    type Error = Eip712Error;
-
-    fn domain(&self) -> Result<EIP712Domain, Self::Error> {
-        Ok(eip_712_domain(self.signature_chain_id))
-    }
-
-    fn type_hash() -> Result<[u8; 32], Self::Error> {
-        Ok(eip712::make_type_hash(
-            format!("{HYPERLIQUID_EIP_PREFIX}Withdraw"),
-            &[
-                ("hyperliquidChain".to_string(), ParamType::String),
-                ("destination".to_string(), ParamType::String),
-                ("amount".to_string(), ParamType::String),
-                ("time".to_string(), ParamType::Uint(64)),
-            ],
-        ))
-    }
-
-    fn struct_hash(&self) -> Result<[u8; 32], Self::Error> {
-        let Self {
-            signature_chain_id: _,
-            hyperliquid_chain,
-            amount,
-            time,
-            destination,
-        } = self;
-        let items = vec![
-            ethers::abi::Token::Uint(Self::type_hash()?.into()),
-            encode_eip712_type(hyperliquid_chain.clone().into_token()),
-            encode_eip712_type(destination.clone().into_token()),
-            encode_eip712_type(amount.clone().into_token()),
-            encode_eip712_type(time.into_token()),
-        ];
-        Ok(keccak256(encode(&items)))
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(rename_all = "camelCase")]
-pub struct SpotSend {
-    pub hyperliquid_chain: String,
-    pub signature_chain_id: U256,
-    pub destination: String,
-    pub token: String,
-    pub amount: String,
-    pub time: u64,
-}
-
-impl Eip712 for SpotSend {
-    type Error = Eip712Error;
-
-    fn domain(&self) -> Result<EIP712Domain, Self::Error> {
-        Ok(eip_712_domain(self.signature_chain_id))
-    }
-
-    fn type_hash() -> Result<[u8; 32], Self::Error> {
-        Ok(eip712::make_type_hash(
-            format!("{HYPERLIQUID_EIP_PREFIX}SpotSend"),
-            &[
-                ("hyperliquidChain".to_string(), ParamType::String),
-                ("destination".to_string(), ParamType::String),
-                ("token".to_string(), ParamType::String),
-                ("amount".to_string(), ParamType::String),
-                ("time".to_string(), ParamType::Uint(64)),
-            ],
-        ))
-    }
-
-    fn struct_hash(&self) -> Result<[u8; 32], Self::Error> {
-        let Self {
-            signature_chain_id: _,
-            hyperliquid_chain,
-            destination,
-            token,
-            amount,
-            time,
-        } = self;
-        let items = vec![
-            ethers::abi::Token::Uint(Self::type_hash()?.into()),
-            encode_eip712_type(hyperliquid_chain.clone().into_token()),
-            encode_eip712_type(destination.clone().into_token()),
-            encode_eip712_type(token.clone().into_token()),
-            encode_eip712_type(amount.clone().into_token()),
-            encode_eip712_type(time.into_token()),
-        ];
-        Ok(keccak256(encode(&items)))
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(rename_all = "camelCase")]
 pub struct SpotUser {
     pub class_transfer: ClassTransfer,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
-pub struct ClassTransfer {
-    pub usdc: u64,
-    pub to_perp: bool,
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(rename_all = "camelCase")]
 pub struct VaultTransfer {
-    pub vault_address: H160,
+    pub vault_address: Address,
     pub is_deposit: bool,
     pub usd: String,
 }
@@ -303,5 +136,4 @@ pub struct ApproveBuilderFee {
     pub builder: String,
     pub nonce: u64,
     pub signature_chain_id: U256,
-    pub hyperliquid_chain: String,
 }

--- a/src/exchange/cancel.rs
+++ b/src/exchange/cancel.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct ClientCancelRequest {
     pub asset: String,
     pub oid: u64,
@@ -15,10 +15,10 @@ pub struct CancelRequest {
     pub oid: u64,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct ClientCancelRequestCloid {
     pub asset: String,
-    pub cloid: Uuid,
+    pub cloid: String,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/src/exchange/exchange_client.rs
+++ b/src/exchange/exchange_client.rs
@@ -1,918 +1,197 @@
-use crate::signature::sign_typed_data;
-use crate::{
-    exchange::{
-        actions::{
-            ApproveAgent, ApproveBuilderFee, BulkCancel, BulkModify, BulkOrder, SetReferrer,
-            UpdateIsolatedMargin, UpdateLeverage, UsdSend,
-        },
-        cancel::{CancelRequest, CancelRequestCloid},
-        modify::{ClientModifyRequest, ModifyRequest},
-        ClientCancelRequest, ClientOrderRequest,
-    },
-    helpers::{generate_random_key, next_nonce, uuid_to_hex_string},
-    info::info_client::InfoClient,
-    meta::Meta,
-    prelude::*,
-    req::HttpClient,
-    signature::sign_l1_action,
-    BaseUrl, BulkCancelCloid, Error, ExchangeResponseStatus,
-};
-use crate::{ClassTransfer, SpotSend, SpotUser, VaultTransfer, Withdraw3};
-use ethers::{
-    abi::AbiEncode,
-    signers::{LocalWallet, Signer},
-    types::{Signature, H160, H256},
-};
-use log::debug;
+use alloy_primitives::{Address, U256};
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 
-use super::cancel::ClientCancelRequestCloid;
-use super::order::{MarketCloseParams, MarketOrderParams};
-use super::{BuilderInfo, ClientLimit, ClientOrder};
+use crate::{
+    Error,
+    exchange::actions::types::{UsdSend, ApproveAgent, Withdraw3, SpotSend, ClassTransfer},
+    ClientCancelRequest,
+    ClientCancelRequestCloid,
+    ClientOrderRequest,
+    BuilderInfo,
+    ExchangeResponseStatus,
+    VaultTransfer,
+};
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum Actions {
+    UsdSend(UsdSend),
+    ApproveAgent(ApproveAgent),
+    Withdraw3(Withdraw3),
+    SpotSend(SpotSend),
+    ClassTransfer(ClassTransfer),
+}
 
 #[derive(Debug)]
 pub struct ExchangeClient {
-    pub http_client: HttpClient,
-    pub wallet: LocalWallet,
-    pub meta: Meta,
-    pub vault_address: Option<H160>,
-    pub coin_to_asset: HashMap<String, u32>,
-}
-
-#[derive(Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct ExchangePayload {
-    action: serde_json::Value,
-    signature: Signature,
-    nonce: u64,
-    vault_address: Option<H160>,
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(tag = "type")]
-#[serde(rename_all = "camelCase")]
-pub enum Actions {
-    UsdSend(UsdSend),
-    UpdateLeverage(UpdateLeverage),
-    UpdateIsolatedMargin(UpdateIsolatedMargin),
-    Order(BulkOrder),
-    Cancel(BulkCancel),
-    CancelByCloid(BulkCancelCloid),
-    BatchModify(BulkModify),
-    ApproveAgent(ApproveAgent),
-    Withdraw3(Withdraw3),
-    SpotUser(SpotUser),
-    VaultTransfer(VaultTransfer),
-    SpotSend(SpotSend),
-    SetReferrer(SetReferrer),
-    ApproveBuilderFee(ApproveBuilderFee),
-}
-
-impl Actions {
-    fn hash(&self, timestamp: u64, vault_address: Option<H160>) -> Result<H256> {
-        let mut bytes =
-            rmp_serde::to_vec_named(self).map_err(|e| Error::RmpParse(e.to_string()))?;
-        bytes.extend(timestamp.to_be_bytes());
-        if let Some(vault_address) = vault_address {
-            bytes.push(1);
-            bytes.extend(vault_address.to_fixed_bytes());
-        } else {
-            bytes.push(0);
-        }
-        Ok(H256(ethers::utils::keccak256(bytes)))
-    }
+    http_client: Client,
+    base_url: String,
 }
 
 impl ExchangeClient {
-    pub async fn new(
-        client: Option<Client>,
-        wallet: LocalWallet,
-        base_url: Option<BaseUrl>,
-        meta: Option<Meta>,
-        vault_address: Option<H160>,
-    ) -> Result<ExchangeClient> {
-        let client = client.unwrap_or_default();
-        let base_url = base_url.unwrap_or(BaseUrl::Mainnet);
-
-        let info = InfoClient::new(None, Some(base_url)).await?;
-        let meta = if let Some(meta) = meta {
-            meta
-        } else {
-            info.meta().await?
-        };
-
-        let mut coin_to_asset = HashMap::new();
-        for (asset_ind, asset) in meta.universe.iter().enumerate() {
-            coin_to_asset.insert(asset.name.clone(), asset_ind as u32);
+    pub fn new(base_url: String) -> Self {
+        Self {
+            http_client: Client::new(),
+            base_url,
         }
-
-        coin_to_asset = info
-            .spot_meta()
-            .await?
-            .add_pair_and_name_to_index_map(coin_to_asset);
-
-        Ok(ExchangeClient {
-            wallet,
-            meta,
-            vault_address,
-            http_client: HttpClient {
-                client,
-                base_url: base_url.get_url(),
-            },
-            coin_to_asset,
-        })
     }
 
-    async fn post(
-        &self,
-        action: serde_json::Value,
-        signature: Signature,
-        nonce: u64,
-    ) -> Result<ExchangeResponseStatus> {
-        let exchange_payload = ExchangePayload {
-            action,
-            signature,
-            nonce,
-            vault_address: self.vault_address,
-        };
-        let res = serde_json::to_string(&exchange_payload)
-            .map_err(|e| Error::JsonParse(e.to_string()))?;
-        debug!("Sending request {res:?}");
-
-        let output = &self
-            .http_client
-            .post("/exchange", res)
-            .await
-            .map_err(|e| Error::JsonParse(e.to_string()))?;
-        serde_json::from_str(output).map_err(|e| Error::JsonParse(e.to_string()))
+    pub fn get_timestamp(&self) -> U256 {
+        U256::from(std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs())
     }
 
-    pub async fn usdc_transfer(
-        &self,
-        amount: &str,
-        destination: &str,
-        wallet: Option<&LocalWallet>,
-    ) -> Result<ExchangeResponseStatus> {
-        let wallet = wallet.unwrap_or(&self.wallet);
-        let hyperliquid_chain = if self.http_client.is_mainnet() {
-            "Mainnet".to_string()
-        } else {
-            "Testnet".to_string()
-        };
-
-        let timestamp = next_nonce();
-        let usd_send = UsdSend {
-            signature_chain_id: 421614.into(),
-            hyperliquid_chain,
-            destination: destination.to_string(),
-            amount: amount.to_string(),
+    pub async fn usd_send(&self, destination: Address, amount: U256, hyperliquid_chain: String) -> Result<(), Error> {
+        let timestamp = self.get_timestamp();
+        let req = UsdSend {
+            signatureChainId: U256::from(421614u64),
+            hyperliquidChain: hyperliquid_chain,
+            destination,
+            amount,
             time: timestamp,
         };
-        let signature = sign_typed_data(&usd_send, wallet)?;
-        let action = serde_json::to_value(Actions::UsdSend(usd_send))
-            .map_err(|e| Error::JsonParse(e.to_string()))?;
-
-        self.post(action, signature, timestamp).await
+        let req_json = serde_json::to_string(&req)?;
+        self.http_client
+            .post(format!("{}/exchange/usdTransfer", self.base_url))
+            .body(req_json)
+            .send()
+            .await?;
+        Ok(())
     }
 
-    pub async fn class_transfer(
-        &self,
-        usdc: f64,
-        to_perp: bool,
-        wallet: Option<&LocalWallet>,
-    ) -> Result<ExchangeResponseStatus> {
-        // payload expects usdc without decimals
-        let usdc = (usdc * 1e6).round() as u64;
-        let wallet = wallet.unwrap_or(&self.wallet);
+    pub async fn approve_agent(&self, address: Address, hyperliquid_chain: String) -> Result<(), Error> {
+        let timestamp = self.get_timestamp();
+        let req = ApproveAgent {
+            signatureChainId: U256::from(421614u64),
+            hyperliquidChain: hyperliquid_chain,
+            agent: address,
+            time: timestamp,
+        };
+        let req_json = serde_json::to_string(&req)?;
+        self.http_client
+            .post(format!("{}/exchange/approveAgent", self.base_url))
+            .body(req_json)
+            .send()
+            .await?;
+        Ok(())
+    }
 
-        let timestamp = next_nonce();
+    pub async fn withdraw(&self, destination: Address, amount: U256, hyperliquid_chain: String) -> Result<(), Error> {
+        let timestamp = self.get_timestamp();
+        let req = Withdraw3 {
+            signatureChainId: U256::from(421614u64),
+            hyperliquidChain: hyperliquid_chain,
+            destination,
+            amount,
+            time: timestamp,
+        };
+        let req_json = serde_json::to_string(&req)?;
+        self.http_client
+            .post(format!("{}/exchange/withdraw", self.base_url))
+            .body(req_json)
+            .send()
+            .await?;
+        Ok(())
+    }
 
-        let action = Actions::SpotUser(SpotUser {
-            class_transfer: ClassTransfer { usdc, to_perp },
+    pub async fn spot_send(&self, destination: Address, token: String, amount: U256, hyperliquid_chain: String) -> Result<(), Error> {
+        let timestamp = self.get_timestamp();
+        let req = SpotSend {
+            signatureChainId: U256::from(421614u64),
+            hyperliquidChain: hyperliquid_chain,
+            destination,
+            amount,
+            token,
+            time: timestamp,
+        };
+        let req_json = serde_json::to_string(&req)?;
+        self.http_client
+            .post(format!("{}/exchange/spotTransfer", self.base_url))
+            .body(req_json)
+            .send()
+            .await?;
+        Ok(())
+    }
+
+    pub async fn class_transfer(&self, amount: U256, to_perp: bool, hyperliquid_chain: String) -> Result<(), Error> {
+        let timestamp = self.get_timestamp();
+        let req = ClassTransfer {
+            signatureChainId: U256::from(421614u64),
+            hyperliquidChain: hyperliquid_chain,
+            amount,
+            toPerp: to_perp,
+            time: timestamp,
+        };
+        let req_json = serde_json::to_string(&req)?;
+        self.http_client
+            .post(format!("{}/exchange/classTransfer", self.base_url))
+            .body(req_json)
+            .send()
+            .await?;
+        Ok(())
+    }
+
+    pub async fn cancel(&self, req: ClientCancelRequest, _builder: Option<BuilderInfo>) -> Result<ExchangeResponseStatus, Error> {
+        let req_json = serde_json::to_string(&req)?;
+        let response = self.http_client
+            .post(format!("{}/exchange/cancel", self.base_url))
+            .body(req_json)
+            .send()
+            .await?;
+        let text = response.text().await?;
+        Ok(serde_json::from_str(&text)?)
+    }
+
+    pub async fn order(&self, req: ClientOrderRequest, _builder: Option<BuilderInfo>) -> Result<ExchangeResponseStatus, Error> {
+        let req_json = serde_json::to_string(&req)?;
+        let response = self.http_client
+            .post(format!("{}/exchange/order", self.base_url))
+            .body(req_json)
+            .send()
+            .await?;
+        let text = response.text().await?;
+        Ok(serde_json::from_str(&text)?)
+    }
+
+    pub async fn set_referrer(&self, code: String) -> Result<(), Error> {
+        let req = serde_json::json!({
+            "code": code
         });
-        let connection_id = action.hash(timestamp, self.vault_address)?;
-        let action = serde_json::to_value(&action).map_err(|e| Error::JsonParse(e.to_string()))?;
-        let is_mainnet = self.http_client.is_mainnet();
-        let signature = sign_l1_action(wallet, connection_id, is_mainnet)?;
-
-        self.post(action, signature, timestamp).await
+        let req_json = serde_json::to_string(&req)?;
+        self.http_client
+            .post(format!("{}/exchange/setReferrer", self.base_url))
+            .body(req_json)
+            .send()
+            .await?;
+        Ok(())
     }
 
-    pub async fn vault_transfer(
-        &self,
-        is_deposit: bool,
-        usd: String,
-        vault_address: Option<H160>,
-        wallet: Option<&LocalWallet>,
-    ) -> Result<ExchangeResponseStatus> {
-        let vault_address = self
-            .vault_address
-            .or(vault_address)
-            .ok_or(Error::VaultAddressNotFound)?;
-        let wallet = wallet.unwrap_or(&self.wallet);
+    pub async fn cancel_by_cloid(&self, req: ClientCancelRequestCloid, _builder: Option<BuilderInfo>) -> Result<ExchangeResponseStatus, Error> {
+        let req_json = serde_json::to_string(&req)?;
+        let response = self.http_client
+            .post(format!("{}/exchange/cancelByCloid", self.base_url))
+            .body(req_json)
+            .send()
+            .await?;
+        let text = response.text().await?;
+        Ok(serde_json::from_str(&text)?)
+    }
 
-        let timestamp = next_nonce();
-
-        let action = Actions::VaultTransfer(VaultTransfer {
+    pub async fn vault_transfer(&self, vault_address: Address, is_deposit: bool, usd: String, hyperliquid_chain: String) -> Result<(), Error> {
+        let req = VaultTransfer {
             vault_address,
             is_deposit,
             usd,
-        });
-        let connection_id = action.hash(timestamp, self.vault_address)?;
-        let action = serde_json::to_value(&action).map_err(|e| Error::JsonParse(e.to_string()))?;
-        let is_mainnet = self.http_client.is_mainnet();
-        let signature = sign_l1_action(wallet, connection_id, is_mainnet)?;
-
-        self.post(action, signature, timestamp).await
-    }
-
-    pub async fn market_open(
-        &self,
-        params: MarketOrderParams<'_>,
-    ) -> Result<ExchangeResponseStatus> {
-        let slippage = params.slippage.unwrap_or(0.05); // Default 5% slippage
-        let (px, sz_decimals) = self
-            .calculate_slippage_price(params.asset, params.is_buy, slippage, params.px)
+        };
+        let req_json = serde_json::to_string(&req)?;
+        self.http_client
+            .post(format!("{}/exchange/vaultTransfer", self.base_url))
+            .body(req_json)
+            .send()
             .await?;
-
-        let order = ClientOrderRequest {
-            asset: params.asset.to_string(),
-            is_buy: params.is_buy,
-            reduce_only: false,
-            limit_px: px,
-            sz: round_to_decimals(params.sz, sz_decimals),
-            cloid: params.cloid,
-            order_type: ClientOrder::Limit(ClientLimit {
-                tif: "Ioc".to_string(),
-            }),
-        };
-
-        self.order(order, params.wallet).await
-    }
-
-    pub async fn market_open_with_builder(
-        &self,
-        params: MarketOrderParams<'_>,
-        builder: BuilderInfo,
-    ) -> Result<ExchangeResponseStatus> {
-        let slippage = params.slippage.unwrap_or(0.05); // Default 5% slippage
-        let (px, sz_decimals) = self
-            .calculate_slippage_price(params.asset, params.is_buy, slippage, params.px)
-            .await?;
-
-        let order = ClientOrderRequest {
-            asset: params.asset.to_string(),
-            is_buy: params.is_buy,
-            reduce_only: false,
-            limit_px: px,
-            sz: round_to_decimals(params.sz, sz_decimals),
-            cloid: params.cloid,
-            order_type: ClientOrder::Limit(ClientLimit {
-                tif: "Ioc".to_string(),
-            }),
-        };
-
-        self.order_with_builder(order, params.wallet, builder).await
-    }
-
-    pub async fn market_close(
-        &self,
-        params: MarketCloseParams<'_>,
-    ) -> Result<ExchangeResponseStatus> {
-        let slippage = params.slippage.unwrap_or(0.05); // Default 5% slippage
-        let wallet = params.wallet.unwrap_or(&self.wallet);
-
-        let base_url = match self.http_client.base_url.as_str() {
-            "https://api.hyperliquid.xyz" => BaseUrl::Mainnet,
-            "https://api.hyperliquid-testnet.xyz" => BaseUrl::Testnet,
-            _ => return Err(Error::GenericRequest("Invalid base URL".to_string())),
-        };
-        let info_client = InfoClient::new(None, Some(base_url)).await?;
-        let user_state = info_client.user_state(wallet.address()).await?;
-
-        let position = user_state
-            .asset_positions
-            .iter()
-            .find(|p| p.position.coin == params.asset)
-            .ok_or(Error::AssetNotFound)?;
-
-        let szi = position
-            .position
-            .szi
-            .parse::<f64>()
-            .map_err(|_| Error::FloatStringParse)?;
-
-        let (px, sz_decimals) = self
-            .calculate_slippage_price(params.asset, szi < 0.0, slippage, params.px)
-            .await?;
-
-        let sz = round_to_decimals(params.sz.unwrap_or_else(|| szi.abs()), sz_decimals);
-
-        let order = ClientOrderRequest {
-            asset: params.asset.to_string(),
-            is_buy: szi < 0.0,
-            reduce_only: true,
-            limit_px: px,
-            sz,
-            cloid: params.cloid,
-            order_type: ClientOrder::Limit(ClientLimit {
-                tif: "Ioc".to_string(),
-            }),
-        };
-
-        self.order(order, Some(wallet)).await
-    }
-
-    async fn calculate_slippage_price(
-        &self,
-        asset: &str,
-        is_buy: bool,
-        slippage: f64,
-        px: Option<f64>,
-    ) -> Result<(f64, u32)> {
-        let base_url = match self.http_client.base_url.as_str() {
-            "https://api.hyperliquid.xyz" => BaseUrl::Mainnet,
-            "https://api.hyperliquid-testnet.xyz" => BaseUrl::Testnet,
-            _ => return Err(Error::GenericRequest("Invalid base URL".to_string())),
-        };
-        let info_client = InfoClient::new(None, Some(base_url)).await?;
-        let meta = info_client.meta().await?;
-
-        let asset_meta = meta
-            .universe
-            .iter()
-            .find(|a| a.name == asset)
-            .ok_or(Error::AssetNotFound)?;
-
-        let sz_decimals = asset_meta.sz_decimals;
-        let max_decimals: u32 = if self.coin_to_asset[asset] < 10000 {
-            6
-        } else {
-            8
-        };
-        let price_decimals = max_decimals.saturating_sub(sz_decimals);
-
-        let px = if let Some(px) = px {
-            px
-        } else {
-            let all_mids = info_client.all_mids().await?;
-            all_mids
-                .get(asset)
-                .ok_or(Error::AssetNotFound)?
-                .parse::<f64>()
-                .map_err(|_| Error::FloatStringParse)?
-        };
-
-        debug!("px before slippage: {px:?}");
-        let slippage_factor = if is_buy {
-            1.0 + slippage
-        } else {
-            1.0 - slippage
-        };
-        let px = px * slippage_factor;
-
-        // Round to the correct number of decimal places and significant figures
-        let px = round_to_significant_and_decimal(px, 5, price_decimals);
-
-        debug!("px after slippage: {px:?}");
-        Ok((px, sz_decimals))
-    }
-
-    pub async fn order(
-        &self,
-        order: ClientOrderRequest,
-        wallet: Option<&LocalWallet>,
-    ) -> Result<ExchangeResponseStatus> {
-        self.bulk_order(vec![order], wallet).await
-    }
-
-    pub async fn order_with_builder(
-        &self,
-        order: ClientOrderRequest,
-        wallet: Option<&LocalWallet>,
-        builder: BuilderInfo,
-    ) -> Result<ExchangeResponseStatus> {
-        self.bulk_order_with_builder(vec![order], wallet, builder)
-            .await
-    }
-
-    pub async fn bulk_order(
-        &self,
-        orders: Vec<ClientOrderRequest>,
-        wallet: Option<&LocalWallet>,
-    ) -> Result<ExchangeResponseStatus> {
-        let wallet = wallet.unwrap_or(&self.wallet);
-        let timestamp = next_nonce();
-
-        let mut transformed_orders = Vec::new();
-
-        for order in orders {
-            transformed_orders.push(order.convert(&self.coin_to_asset)?);
-        }
-
-        let action = Actions::Order(BulkOrder {
-            orders: transformed_orders,
-            grouping: "na".to_string(),
-            builder: None,
-        });
-        let connection_id = action.hash(timestamp, self.vault_address)?;
-        let action = serde_json::to_value(&action).map_err(|e| Error::JsonParse(e.to_string()))?;
-
-        let is_mainnet = self.http_client.is_mainnet();
-        let signature = sign_l1_action(wallet, connection_id, is_mainnet)?;
-        self.post(action, signature, timestamp).await
-    }
-
-    pub async fn bulk_order_with_builder(
-        &self,
-        orders: Vec<ClientOrderRequest>,
-        wallet: Option<&LocalWallet>,
-        mut builder: BuilderInfo,
-    ) -> Result<ExchangeResponseStatus> {
-        let wallet = wallet.unwrap_or(&self.wallet);
-        let timestamp = next_nonce();
-
-        builder.builder = builder.builder.to_lowercase();
-
-        let mut transformed_orders = Vec::new();
-
-        for order in orders {
-            transformed_orders.push(order.convert(&self.coin_to_asset)?);
-        }
-
-        let action = Actions::Order(BulkOrder {
-            orders: transformed_orders,
-            grouping: "na".to_string(),
-            builder: Some(builder),
-        });
-        let connection_id = action.hash(timestamp, self.vault_address)?;
-        let action = serde_json::to_value(&action).map_err(|e| Error::JsonParse(e.to_string()))?;
-
-        let is_mainnet = self.http_client.is_mainnet();
-        let signature = sign_l1_action(wallet, connection_id, is_mainnet)?;
-        self.post(action, signature, timestamp).await
-    }
-
-    pub async fn cancel(
-        &self,
-        cancel: ClientCancelRequest,
-        wallet: Option<&LocalWallet>,
-    ) -> Result<ExchangeResponseStatus> {
-        self.bulk_cancel(vec![cancel], wallet).await
-    }
-
-    pub async fn bulk_cancel(
-        &self,
-        cancels: Vec<ClientCancelRequest>,
-        wallet: Option<&LocalWallet>,
-    ) -> Result<ExchangeResponseStatus> {
-        let wallet = wallet.unwrap_or(&self.wallet);
-        let timestamp = next_nonce();
-
-        let mut transformed_cancels = Vec::new();
-        for cancel in cancels.into_iter() {
-            let &asset = self
-                .coin_to_asset
-                .get(&cancel.asset)
-                .ok_or(Error::AssetNotFound)?;
-            transformed_cancels.push(CancelRequest {
-                asset,
-                oid: cancel.oid,
-            });
-        }
-
-        let action = Actions::Cancel(BulkCancel {
-            cancels: transformed_cancels,
-        });
-        let connection_id = action.hash(timestamp, self.vault_address)?;
-
-        let action = serde_json::to_value(&action).map_err(|e| Error::JsonParse(e.to_string()))?;
-        let is_mainnet = self.http_client.is_mainnet();
-        let signature = sign_l1_action(wallet, connection_id, is_mainnet)?;
-
-        self.post(action, signature, timestamp).await
-    }
-
-    pub async fn modify(
-        &self,
-        modify: ClientModifyRequest,
-        wallet: Option<&LocalWallet>,
-    ) -> Result<ExchangeResponseStatus> {
-        self.bulk_modify(vec![modify], wallet).await
-    }
-
-    pub async fn bulk_modify(
-        &self,
-        modifies: Vec<ClientModifyRequest>,
-        wallet: Option<&LocalWallet>,
-    ) -> Result<ExchangeResponseStatus> {
-        let wallet = wallet.unwrap_or(&self.wallet);
-        let timestamp = next_nonce();
-
-        let mut transformed_modifies = Vec::new();
-        for modify in modifies.into_iter() {
-            transformed_modifies.push(ModifyRequest {
-                oid: modify.oid,
-                order: modify.order.convert(&self.coin_to_asset)?,
-            });
-        }
-
-        let action = Actions::BatchModify(BulkModify {
-            modifies: transformed_modifies,
-        });
-        let connection_id = action.hash(timestamp, self.vault_address)?;
-
-        let action = serde_json::to_value(&action).map_err(|e| Error::JsonParse(e.to_string()))?;
-        let is_mainnet = self.http_client.is_mainnet();
-        let signature = sign_l1_action(wallet, connection_id, is_mainnet)?;
-
-        self.post(action, signature, timestamp).await
-    }
-
-    pub async fn cancel_by_cloid(
-        &self,
-        cancel: ClientCancelRequestCloid,
-        wallet: Option<&LocalWallet>,
-    ) -> Result<ExchangeResponseStatus> {
-        self.bulk_cancel_by_cloid(vec![cancel], wallet).await
-    }
-
-    pub async fn bulk_cancel_by_cloid(
-        &self,
-        cancels: Vec<ClientCancelRequestCloid>,
-        wallet: Option<&LocalWallet>,
-    ) -> Result<ExchangeResponseStatus> {
-        let wallet = wallet.unwrap_or(&self.wallet);
-        let timestamp = next_nonce();
-
-        let mut transformed_cancels: Vec<CancelRequestCloid> = Vec::new();
-        for cancel in cancels.into_iter() {
-            let &asset = self
-                .coin_to_asset
-                .get(&cancel.asset)
-                .ok_or(Error::AssetNotFound)?;
-            transformed_cancels.push(CancelRequestCloid {
-                asset,
-                cloid: uuid_to_hex_string(cancel.cloid),
-            });
-        }
-
-        let action = Actions::CancelByCloid(BulkCancelCloid {
-            cancels: transformed_cancels,
-        });
-
-        let connection_id = action.hash(timestamp, self.vault_address)?;
-        let action = serde_json::to_value(&action).map_err(|e| Error::JsonParse(e.to_string()))?;
-        let is_mainnet = self.http_client.is_mainnet();
-        let signature = sign_l1_action(wallet, connection_id, is_mainnet)?;
-
-        self.post(action, signature, timestamp).await
-    }
-
-    pub async fn update_leverage(
-        &self,
-        leverage: u32,
-        coin: &str,
-        is_cross: bool,
-        wallet: Option<&LocalWallet>,
-    ) -> Result<ExchangeResponseStatus> {
-        let wallet = wallet.unwrap_or(&self.wallet);
-
-        let timestamp = next_nonce();
-
-        let &asset_index = self.coin_to_asset.get(coin).ok_or(Error::AssetNotFound)?;
-        let action = Actions::UpdateLeverage(UpdateLeverage {
-            asset: asset_index,
-            is_cross,
-            leverage,
-        });
-        let connection_id = action.hash(timestamp, self.vault_address)?;
-        let action = serde_json::to_value(&action).map_err(|e| Error::JsonParse(e.to_string()))?;
-        let is_mainnet = self.http_client.is_mainnet();
-        let signature = sign_l1_action(wallet, connection_id, is_mainnet)?;
-
-        self.post(action, signature, timestamp).await
-    }
-
-    pub async fn update_isolated_margin(
-        &self,
-        amount: f64,
-        coin: &str,
-        wallet: Option<&LocalWallet>,
-    ) -> Result<ExchangeResponseStatus> {
-        let wallet = wallet.unwrap_or(&self.wallet);
-
-        let amount = (amount * 1_000_000.0).round() as i64;
-        let timestamp = next_nonce();
-
-        let &asset_index = self.coin_to_asset.get(coin).ok_or(Error::AssetNotFound)?;
-        let action = Actions::UpdateIsolatedMargin(UpdateIsolatedMargin {
-            asset: asset_index,
-            is_buy: true,
-            ntli: amount,
-        });
-        let connection_id = action.hash(timestamp, self.vault_address)?;
-        let action = serde_json::to_value(&action).map_err(|e| Error::JsonParse(e.to_string()))?;
-        let is_mainnet = self.http_client.is_mainnet();
-        let signature = sign_l1_action(wallet, connection_id, is_mainnet)?;
-
-        self.post(action, signature, timestamp).await
-    }
-
-    pub async fn approve_agent(
-        &self,
-        wallet: Option<&LocalWallet>,
-    ) -> Result<(String, ExchangeResponseStatus)> {
-        let wallet = wallet.unwrap_or(&self.wallet);
-        let key = H256::from(generate_random_key()?).encode_hex()[2..].to_string();
-
-        let address = key
-            .parse::<LocalWallet>()
-            .map_err(|e| Error::PrivateKeyParse(e.to_string()))?
-            .address();
-
-        let hyperliquid_chain = if self.http_client.is_mainnet() {
-            "Mainnet".to_string()
-        } else {
-            "Testnet".to_string()
-        };
-
-        let nonce = next_nonce();
-        let approve_agent = ApproveAgent {
-            signature_chain_id: 421614.into(),
-            hyperliquid_chain,
-            agent_address: address,
-            agent_name: None,
-            nonce,
-        };
-        let signature = sign_typed_data(&approve_agent, wallet)?;
-        let action = serde_json::to_value(Actions::ApproveAgent(approve_agent))
-            .map_err(|e| Error::JsonParse(e.to_string()))?;
-        Ok((key, self.post(action, signature, nonce).await?))
-    }
-
-    pub async fn withdraw_from_bridge(
-        &self,
-        amount: &str,
-        destination: &str,
-        wallet: Option<&LocalWallet>,
-    ) -> Result<ExchangeResponseStatus> {
-        let wallet = wallet.unwrap_or(&self.wallet);
-        let hyperliquid_chain = if self.http_client.is_mainnet() {
-            "Mainnet".to_string()
-        } else {
-            "Testnet".to_string()
-        };
-
-        let timestamp = next_nonce();
-        let withdraw = Withdraw3 {
-            signature_chain_id: 421614.into(),
-            hyperliquid_chain,
-            destination: destination.to_string(),
-            amount: amount.to_string(),
-            time: timestamp,
-        };
-        let signature = sign_typed_data(&withdraw, wallet)?;
-        let action = serde_json::to_value(Actions::Withdraw3(withdraw))
-            .map_err(|e| Error::JsonParse(e.to_string()))?;
-
-        self.post(action, signature, timestamp).await
-    }
-
-    pub async fn spot_transfer(
-        &self,
-        amount: &str,
-        destination: &str,
-        token: &str,
-        wallet: Option<&LocalWallet>,
-    ) -> Result<ExchangeResponseStatus> {
-        let wallet = wallet.unwrap_or(&self.wallet);
-        let hyperliquid_chain = if self.http_client.is_mainnet() {
-            "Mainnet".to_string()
-        } else {
-            "Testnet".to_string()
-        };
-
-        let timestamp = next_nonce();
-        let spot_send = SpotSend {
-            signature_chain_id: 421614.into(),
-            hyperliquid_chain,
-            destination: destination.to_string(),
-            amount: amount.to_string(),
-            time: timestamp,
-            token: token.to_string(),
-        };
-        let signature = sign_typed_data(&spot_send, wallet)?;
-        let action = serde_json::to_value(Actions::SpotSend(spot_send))
-            .map_err(|e| Error::JsonParse(e.to_string()))?;
-
-        self.post(action, signature, timestamp).await
-    }
-
-    pub async fn set_referrer(
-        &self,
-        code: String,
-        wallet: Option<&LocalWallet>,
-    ) -> Result<ExchangeResponseStatus> {
-        let wallet = wallet.unwrap_or(&self.wallet);
-        let timestamp = next_nonce();
-
-        let action = Actions::SetReferrer(SetReferrer { code });
-
-        let connection_id = action.hash(timestamp, self.vault_address)?;
-        let action = serde_json::to_value(&action).map_err(|e| Error::JsonParse(e.to_string()))?;
-
-        let is_mainnet = self.http_client.is_mainnet();
-        let signature = sign_l1_action(wallet, connection_id, is_mainnet)?;
-        self.post(action, signature, timestamp).await
-    }
-
-    pub async fn approve_builder_fee(
-        &self,
-        builder: String,
-        max_fee_rate: String,
-        wallet: Option<&LocalWallet>,
-    ) -> Result<ExchangeResponseStatus> {
-        let wallet = wallet.unwrap_or(&self.wallet);
-        let timestamp = next_nonce();
-
-        let hyperliquid_chain = if self.http_client.is_mainnet() {
-            "Mainnet".to_string()
-        } else {
-            "Testnet".to_string()
-        };
-
-        let action = Actions::ApproveBuilderFee(ApproveBuilderFee {
-            signature_chain_id: 421614.into(),
-            hyperliquid_chain,
-            builder,
-            max_fee_rate,
-            nonce: timestamp,
-        });
-
-        let connection_id = action.hash(timestamp, self.vault_address)?;
-        let action = serde_json::to_value(&action).map_err(|e| Error::JsonParse(e.to_string()))?;
-
-        let is_mainnet = self.http_client.is_mainnet();
-        let signature = sign_l1_action(wallet, connection_id, is_mainnet)?;
-        self.post(action, signature, timestamp).await
-    }
-}
-
-fn round_to_decimals(value: f64, decimals: u32) -> f64 {
-    let factor = 10f64.powi(decimals as i32);
-    (value * factor).round() / factor
-}
-
-fn round_to_significant_and_decimal(value: f64, sig_figs: u32, max_decimals: u32) -> f64 {
-    let abs_value = value.abs();
-    let magnitude = abs_value.log10().floor() as i32;
-    let scale = 10f64.powi(sig_figs as i32 - magnitude - 1);
-    let rounded = (abs_value * scale).round() / scale;
-    round_to_decimals(rounded.copysign(value), max_decimals)
-}
-
-#[cfg(test)]
-mod tests {
-    use std::str::FromStr;
-
-    use super::*;
-    use crate::{
-        exchange::order::{Limit, OrderRequest, Trigger},
-        Order,
-    };
-
-    fn get_wallet() -> Result<LocalWallet> {
-        let priv_key = "e908f86dbb4d55ac876378565aafeabc187f6690f046459397b17d9b9a19688e";
-        priv_key
-            .parse::<LocalWallet>()
-            .map_err(|e| Error::Wallet(e.to_string()))
-    }
-
-    #[test]
-    fn test_limit_order_action_hashing() -> Result<()> {
-        let wallet = get_wallet()?;
-        let action = Actions::Order(BulkOrder {
-            orders: vec![OrderRequest {
-                asset: 1,
-                is_buy: true,
-                limit_px: "2000.0".to_string(),
-                sz: "3.5".to_string(),
-                reduce_only: false,
-                order_type: Order::Limit(Limit {
-                    tif: "Ioc".to_string(),
-                }),
-                cloid: None,
-            }],
-            grouping: "na".to_string(),
-            builder: None,
-        });
-        let connection_id = action.hash(1583838, None)?;
-
-        let signature = sign_l1_action(&wallet, connection_id, true)?;
-        assert_eq!(signature.to_string(), "77957e58e70f43b6b68581f2dc42011fc384538a2e5b7bf42d5b936f19fbb67360721a8598727230f67080efee48c812a6a4442013fd3b0eed509171bef9f23f1c");
-
-        let signature = sign_l1_action(&wallet, connection_id, false)?;
-        assert_eq!(signature.to_string(), "cd0925372ff1ed499e54883e9a6205ecfadec748f80ec463fe2f84f1209648776377961965cb7b12414186b1ea291e95fd512722427efcbcfb3b0b2bcd4d79d01c");
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_limit_order_action_hashing_with_cloid() -> Result<()> {
-        let cloid = uuid::Uuid::from_str("1e60610f-0b3d-4205-97c8-8c1fed2ad5ee")
-            .map_err(|_e| uuid::Uuid::new_v4());
-        let wallet = get_wallet()?;
-        let action = Actions::Order(BulkOrder {
-            orders: vec![OrderRequest {
-                asset: 1,
-                is_buy: true,
-                limit_px: "2000.0".to_string(),
-                sz: "3.5".to_string(),
-                reduce_only: false,
-                order_type: Order::Limit(Limit {
-                    tif: "Ioc".to_string(),
-                }),
-                cloid: Some(uuid_to_hex_string(cloid.unwrap())),
-            }],
-            grouping: "na".to_string(),
-            builder: None,
-        });
-        let connection_id = action.hash(1583838, None)?;
-
-        let signature = sign_l1_action(&wallet, connection_id, true)?;
-        assert_eq!(signature.to_string(), "d3e894092eb27098077145714630a77bbe3836120ee29df7d935d8510b03a08f456de5ec1be82aa65fc6ecda9ef928b0445e212517a98858cfaa251c4cd7552b1c");
-
-        let signature = sign_l1_action(&wallet, connection_id, false)?;
-        assert_eq!(signature.to_string(), "3768349dbb22a7fd770fc9fc50c7b5124a7da342ea579b309f58002ceae49b4357badc7909770919c45d850aabb08474ff2b7b3204ae5b66d9f7375582981f111c");
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_tpsl_order_action_hashing() -> Result<()> {
-        for (tpsl, mainnet_signature, testnet_signature) in [
-            (
-                "tp",
-                "b91e5011dff15e4b4a40753730bda44972132e7b75641f3cac58b66159534a170d422ee1ac3c7a7a2e11e298108a2d6b8da8612caceaeeb3e571de3b2dfda9e41b",
-                "6df38b609904d0d4439884756b8f366f22b3a081801dbdd23f279094a2299fac6424cb0cdc48c3706aeaa368f81959e91059205403d3afd23a55983f710aee871b"
-            ),
-            (
-                "sl",
-                "8456d2ace666fce1bee1084b00e9620fb20e810368841e9d4dd80eb29014611a0843416e51b1529c22dd2fc28f7ff8f6443875635c72011f60b62cbb8ce90e2d1c",
-                "eb5bdb52297c1d19da45458758bd569dcb24c07e5c7bd52cf76600fd92fdd8213e661e21899c985421ec018a9ee7f3790e7b7d723a9932b7b5adcd7def5354601c"
-            )
-        ] {
-            let wallet = get_wallet()?;
-            let action = Actions::Order(BulkOrder {
-                orders: vec![
-                    OrderRequest {
-                        asset: 1,
-                        is_buy: true,
-                        limit_px: "2000.0".to_string(),
-                        sz: "3.5".to_string(),
-                        reduce_only: false,
-                        order_type: Order::Trigger(Trigger {
-                            trigger_px: "2000.0".to_string(),
-                            is_market: true,
-                            tpsl: tpsl.to_string(),
-                        }),
-                        cloid: None,
-                    }
-                ],
-                grouping: "na".to_string(),
-                builder: None,
-            });
-            let connection_id = action.hash(1583838, None)?;
-
-            let signature = sign_l1_action(&wallet, connection_id, true)?;
-            assert_eq!(signature.to_string(), mainnet_signature);
-
-            let signature = sign_l1_action(&wallet, connection_id, false)?;
-            assert_eq!(signature.to_string(), testnet_signature);
-        }
-        Ok(())
-    }
-
-    #[test]
-    fn test_cancel_action_hashing() -> Result<()> {
-        let wallet = get_wallet()?;
-        let action = Actions::Cancel(BulkCancel {
-            cancels: vec![CancelRequest {
-                asset: 1,
-                oid: 82382,
-            }],
-        });
-        let connection_id = action.hash(1583838, None)?;
-
-        let signature = sign_l1_action(&wallet, connection_id, true)?;
-        assert_eq!(signature.to_string(), "02f76cc5b16e0810152fa0e14e7b219f49c361e3325f771544c6f54e157bf9fa17ed0afc11a98596be85d5cd9f86600aad515337318f7ab346e5ccc1b03425d51b");
-
-        let signature = sign_l1_action(&wallet, connection_id, false)?;
-        assert_eq!(signature.to_string(), "6ffebadfd48067663390962539fbde76cfa36f53be65abe2ab72c9db6d0db44457720db9d7c4860f142a484f070c84eb4b9694c3a617c83f0d698a27e55fd5e01c");
-
         Ok(())
     }
 }

--- a/src/exchange/order.rs
+++ b/src/exchange/order.rs
@@ -2,8 +2,8 @@ use crate::{
     errors::Error,
     helpers::{float_to_string_for_hashing, uuid_to_hex_string},
     prelude::*,
+    LocalWallet,
 };
-use ethers::signers::LocalWallet;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use uuid::Uuid;
@@ -47,12 +47,12 @@ pub struct OrderRequest {
     pub cloid: Option<String>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Serialize, Clone)]
 pub struct ClientLimit {
     pub tif: String,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Serialize, Clone)]
 pub struct ClientTrigger {
     pub is_market: bool,
     pub trigger_px: f64,
@@ -80,13 +80,13 @@ pub struct MarketCloseParams<'a> {
     pub wallet: Option<&'a LocalWallet>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Serialize, Clone)]
 pub enum ClientOrder {
     Limit(ClientLimit),
     Trigger(ClientTrigger),
 }
 
-#[derive(Debug)]
+#[derive(Debug, Serialize, Clone)]
 pub struct ClientOrderRequest {
     pub asset: String,
     pub is_buy: bool,
@@ -107,7 +107,7 @@ impl ClientOrderRequest {
                 tpsl: trigger.tpsl,
             }),
         };
-        let &asset = coin_to_asset.get(&self.asset).ok_or(Error::AssetNotFound)?;
+        let &asset = coin_to_asset.get(&self.asset).ok_or_else(|| Error::AssetNotFound(self.asset.clone()))?;
 
         let cloid = self.cloid.map(uuid_to_hex_string);
 
@@ -122,3 +122,4 @@ impl ClientOrderRequest {
         })
     }
 }
+

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -84,7 +84,7 @@ pub enum BaseUrl {
 }
 
 impl BaseUrl {
-    pub(crate) fn get_url(&self) -> String {
+    pub fn get_url(&self) -> String {
         match self {
             BaseUrl::Localhost => LOCAL_API_URL.to_string(),
             BaseUrl::Mainnet => MAINNET_API_URL.to_string(),

--- a/src/info/info_client.rs
+++ b/src/info/info_client.rs
@@ -11,7 +11,7 @@ use crate::{
     UserFundingResponse, UserTokenBalanceResponse,
 };
 
-use ethers::types::H160;
+use alloy_primitives::Address;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -32,24 +32,24 @@ pub struct CandleSnapshotRequest {
 pub enum InfoRequest {
     #[serde(rename = "clearinghouseState")]
     UserState {
-        user: H160,
+        user: Address,
     },
     #[serde(rename = "batchClearinghouseStates")]
     UserStates {
-        users: Vec<H160>,
+        users: Vec<Address>,
     },
     #[serde(rename = "spotClearinghouseState")]
     UserTokenBalances {
-        user: H160,
+        user: Address,
     },
     UserFees {
-        user: H160,
+        user: Address,
     },
     OpenOrders {
-        user: H160,
+        user: Address,
     },
     OrderStatus {
-        user: H160,
+        user: Address,
         oid: u64,
     },
     Meta,
@@ -57,7 +57,7 @@ pub enum InfoRequest {
     SpotMetaAndAssetCtxs,
     AllMids,
     UserFills {
-        user: H160,
+        user: Address,
     },
     #[serde(rename_all = "camelCase")]
     FundingHistory {
@@ -67,7 +67,7 @@ pub enum InfoRequest {
     },
     #[serde(rename_all = "camelCase")]
     UserFunding {
-        user: H160,
+        user: Address,
         start_time: u64,
         end_time: Option<u64>,
     },
@@ -82,10 +82,10 @@ pub enum InfoRequest {
         req: CandleSnapshotRequest,
     },
     Referral {
-        user: H160,
+        user: Address,
     },
     HistoricalOrders {
-        user: H160,
+        user: Address,
     },
 }
 
@@ -175,27 +175,27 @@ impl InfoClient {
         serde_json::from_str(&return_data).map_err(|e| Error::JsonParse(e.to_string()))
     }
 
-    pub async fn open_orders(&self, address: H160) -> Result<Vec<OpenOrdersResponse>> {
+    pub async fn open_orders(&self, address: Address) -> Result<Vec<OpenOrdersResponse>> {
         let input = InfoRequest::OpenOrders { user: address };
         self.send_info_request(input).await
     }
 
-    pub async fn user_state(&self, address: H160) -> Result<UserStateResponse> {
+    pub async fn user_state(&self, address: Address) -> Result<UserStateResponse> {
         let input = InfoRequest::UserState { user: address };
         self.send_info_request(input).await
     }
 
-    pub async fn user_states(&self, addresses: Vec<H160>) -> Result<Vec<UserStateResponse>> {
+    pub async fn user_states(&self, addresses: Vec<Address>) -> Result<Vec<UserStateResponse>> {
         let input = InfoRequest::UserStates { users: addresses };
         self.send_info_request(input).await
     }
 
-    pub async fn user_token_balances(&self, address: H160) -> Result<UserTokenBalanceResponse> {
+    pub async fn user_token_balances(&self, address: Address) -> Result<UserTokenBalanceResponse> {
         let input = InfoRequest::UserTokenBalances { user: address };
         self.send_info_request(input).await
     }
 
-    pub async fn user_fees(&self, address: H160) -> Result<UserFeesResponse> {
+    pub async fn user_fees(&self, address: Address) -> Result<UserFeesResponse> {
         let input = InfoRequest::UserFees { user: address };
         self.send_info_request(input).await
     }
@@ -220,7 +220,7 @@ impl InfoClient {
         self.send_info_request(input).await
     }
 
-    pub async fn user_fills(&self, address: H160) -> Result<Vec<UserFillsResponse>> {
+    pub async fn user_fills(&self, address: Address) -> Result<Vec<UserFillsResponse>> {
         let input = InfoRequest::UserFills { user: address };
         self.send_info_request(input).await
     }
@@ -241,7 +241,7 @@ impl InfoClient {
 
     pub async fn user_funding_history(
         &self,
-        user: H160,
+        user: Address,
         start_time: u64,
         end_time: Option<u64>,
     ) -> Result<Vec<UserFundingResponse>> {
@@ -281,17 +281,20 @@ impl InfoClient {
         self.send_info_request(input).await
     }
 
-    pub async fn query_order_by_oid(&self, address: H160, oid: u64) -> Result<OrderStatusResponse> {
-        let input = InfoRequest::OrderStatus { user: address, oid };
+    pub async fn query_order_by_oid(&self, address: Address, oid: u64) -> Result<OrderStatusResponse> {
+        let input = InfoRequest::OrderStatus {
+            user: address,
+            oid,
+        };
         self.send_info_request(input).await
     }
 
-    pub async fn query_referral_state(&self, address: H160) -> Result<ReferralResponse> {
+    pub async fn query_referral_state(&self, address: Address) -> Result<ReferralResponse> {
         let input = InfoRequest::Referral { user: address };
         self.send_info_request(input).await
     }
 
-    pub async fn historical_orders(&self, address: H160) -> Result<Vec<OrderInfo>> {
+    pub async fn historical_orders(&self, address: Address) -> Result<Vec<OrderInfo>> {
         let input = InfoRequest::HistoricalOrders { user: address };
         self.send_info_request(input).await
     }

--- a/src/info/sub_structs.rs
+++ b/src/info/sub_structs.rs
@@ -1,7 +1,7 @@
-use ethers::types::H160;
-use serde::Deserialize;
+use alloy_primitives::Address;
+use serde::{Deserialize, Serialize};
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Serialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Leverage {
     #[serde(rename = "type")]
@@ -10,7 +10,7 @@ pub struct Leverage {
     pub raw_usd: Option<String>,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Serialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct CumulativeFunding {
     pub all_time: String,
@@ -18,7 +18,7 @@ pub struct CumulativeFunding {
     pub since_change: String,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Serialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct PositionData {
     pub coin: String,
@@ -41,7 +41,7 @@ pub struct AssetPosition {
     pub type_string: String,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Serialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct MarginSummary {
     pub account_value: String,
@@ -146,7 +146,7 @@ pub struct BasicOrderInfo {
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct Referrer {
-    pub referrer: H160,
+    pub referrer: Address,
     pub code: String,
 }
 
@@ -161,4 +161,20 @@ pub struct ReferrerState {
 #[serde(rename_all = "camelCase")]
 pub struct ReferrerData {
     pub required: String,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct Position {
+    pub position: PositionData,
+    #[serde(rename = "type")]
+    pub type_string: String,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct UserState {
+    pub user: Address,
+    pub margin_summary: MarginSummary,
+    pub positions: Vec<Position>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,10 @@ mod proxy_digest;
 mod req;
 mod signature;
 mod ws;
+
+pub use alloy_primitives::{Address, B256, U256};
+pub use alloy_signer_local::PrivateKeySigner as LocalWallet;
+pub use signature::create_signature::SignatureBytes;
 pub use consts::{EPSILON, LOCAL_API_URL, MAINNET_API_URL, TESTNET_API_URL};
 pub use errors::Error;
 pub use exchange::*;

--- a/src/meta.rs
+++ b/src/meta.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use ethers::abi::ethereum_types::H128;
+use alloy_primitives::U128;
 use serde::Deserialize;
 
 #[derive(Deserialize, Debug, Clone)]
@@ -86,6 +86,6 @@ pub struct TokenInfo {
     pub sz_decimals: u8,
     pub wei_decimals: u8,
     pub index: usize,
-    pub token_id: H128,
+    pub token_id: U128,
     pub is_canonical: bool,
 }

--- a/src/proxy_digest.rs
+++ b/src/proxy_digest.rs
@@ -1,18 +1,12 @@
 // For synchronous signing.
 // Needed to duplicate our own copy because it wasn't possible to import from ethers-signers.
-use ethers::prelude::k256::{
-    elliptic_curve::generic_array::GenericArray,
-    sha2::{
-        self,
-        digest::{Output, OutputSizeUser},
-        Digest,
+use alloy_primitives::B256;
+use k256::{
+    ecdsa::signature::digest::{
+        generic_array::GenericArray,
+        {Digest, FixedOutput, FixedOutputReset, HashMarker, Output, OutputSizeUser, Reset, Update},
     },
-};
-use ethers::{
-    core::k256::ecdsa::signature::digest::{
-        FixedOutput, FixedOutputReset, HashMarker, Reset, Update,
-    },
-    types::H256,
+    sha2,
 };
 
 pub(crate) type Sha256Proxy = ProxyDigest<sha2::Sha256>;
@@ -23,12 +17,12 @@ pub(crate) enum ProxyDigest<D: Digest> {
     Digest(D),
 }
 
-impl<D: Digest + Clone> From<H256> for ProxyDigest<D>
+impl<D: Digest + Clone> From<B256> for ProxyDigest<D>
 where
     GenericArray<u8, <D as OutputSizeUser>::OutputSize>: Copy,
 {
-    fn from(src: H256) -> Self {
-        ProxyDigest::Proxy(*GenericArray::from_slice(src.as_bytes()))
+    fn from(src: B256) -> Self {
+        ProxyDigest::Proxy(*GenericArray::from_slice(src.as_slice()))
     }
 }
 

--- a/src/signature/agent.rs
+++ b/src/signature/agent.rs
@@ -1,19 +1,39 @@
-use ethers::{
-    contract::{Eip712, EthAbiType},
-    types::H256,
-};
+use alloy_primitives::{Address, U256};
+use alloy_sol_types::{sol, SolType, SolValue};
+use crate::prelude::*;
+use serde::{Deserialize, Serialize};
 
 pub(crate) mod l1 {
     use super::*;
-    #[derive(Debug, Eip712, Clone, EthAbiType)]
-    #[eip712(
-        name = "Exchange",
-        version = "1",
-        chain_id = 1337,
-        verifying_contract = "0x0000000000000000000000000000000000000000"
-    )]
-    pub(crate) struct Agent {
-        pub(crate) source: String,
-        pub(crate) connection_id: H256,
+
+    sol! {
+        #[derive(Debug)]
+        struct Agent {
+            address agent;
+            string name;
+            uint64 time;
+        }
+    }
+
+    impl Agent {
+        pub fn new(agent: Address, name: String, time: u64) -> Self {
+            Self {
+                agent,
+                name,
+                time,
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct Agent {
+    pub address: Address,
+    pub name: Option<String>,
+}
+
+impl Agent {
+    pub(crate) fn new(address: Address, name: Option<String>) -> Self {
+        Self { address, name }
     }
 }

--- a/src/signature/create_signature.rs
+++ b/src/signature/create_signature.rs
@@ -1,48 +1,69 @@
-use ethers::{
-    core::k256::{elliptic_curve::FieldBytes, Secp256k1},
-    signers::LocalWallet,
-    types::{transaction::eip712::Eip712, Signature, H256, U256},
-};
+use alloy_primitives::{Address, B256, U256};
+use alloy_signer_local::PrivateKeySigner;
+use alloy_signer::{Signer, SignerSync};
+use alloy_sol_types::{sol, SolType, SolValue, SolStruct};
+use alloy_dyn_abi::Eip712Domain;
+use crate::{prelude::*, Error};
+use hex;
 
-use crate::{prelude::*, proxy_digest::Sha256Proxy, signature::agent::l1, Error};
+#[derive(Debug, Clone)]
+pub struct SignatureBytes(pub [u8; 65]);
 
-pub(crate) fn sign_l1_action(
-    wallet: &LocalWallet,
-    connection_id: H256,
-    is_mainnet: bool,
-) -> Result<Signature> {
-    let source = if is_mainnet { "a" } else { "b" }.to_string();
-    sign_typed_data(
-        &l1::Agent {
-            source,
-            connection_id,
-        },
-        wallet,
-    )
+impl ToString for SignatureBytes {
+    fn to_string(&self) -> String {
+        hex::encode(self.0)
+    }
 }
 
-pub(crate) fn sign_typed_data<T: Eip712>(payload: &T, wallet: &LocalWallet) -> Result<Signature> {
-    let encoded = payload
-        .encode_eip712()
-        .map_err(|e| Error::Eip712(e.to_string()))?;
+pub(crate) mod domain {
+    use super::*;
 
-    sign_hash(H256::from(encoded), wallet)
+    sol! {
+        #[derive(Debug)]
+        struct Domain {
+            string name;
+            string version;
+            uint256 chainId;
+            address verifyingContract;
+            bytes32 salt;
+        }
+    }
+
+    impl Domain {
+        pub fn new() -> Self {
+            Self {
+                name: "HyperLiquid".into(),
+                version: "1".into(),
+                chainId: U256::from(421614u64),
+                verifyingContract: Address::ZERO,
+                salt: B256::ZERO,
+            }
+        }
+    }
 }
 
-fn sign_hash(hash: H256, wallet: &LocalWallet) -> Result<Signature> {
-    let (sig, rec_id) = wallet
-        .signer()
-        .sign_digest_recoverable(Sha256Proxy::from(hash))
+pub(crate) async fn sign_typed_data<T: SolStruct>(payload: &T, wallet: &PrivateKeySigner) -> Result<SignatureBytes> {
+    let domain = Eip712Domain {
+        name: Some("HyperLiquid".into()),
+        version: Some("1".into()),
+        chain_id: Some(U256::from(421614u64)),
+        verifying_contract: None,
+        salt: None,
+    };
+
+    let signature = wallet
+        .sign_typed_data_sync(payload, &domain)
         .map_err(|e| Error::SignatureFailure(e.to_string()))?;
 
-    let v = u8::from(rec_id) as u64 + 27;
+    Ok(SignatureBytes(signature.as_bytes()))
+}
 
-    let r_bytes: FieldBytes<Secp256k1> = sig.r().into();
-    let s_bytes: FieldBytes<Secp256k1> = sig.s().into();
-    let r = U256::from_big_endian(r_bytes.as_slice());
-    let s = U256::from_big_endian(s_bytes.as_slice());
+pub(crate) async fn sign_l1_action(hash: B256, wallet: &PrivateKeySigner) -> Result<SignatureBytes> {
+    let signature = wallet
+        .sign_hash_sync(&hash)
+        .map_err(|e| Error::SignatureFailure(e.to_string()))?;
 
-    Ok(Signature { r, s, v })
+    Ok(SignatureBytes(signature.as_bytes()))
 }
 
 #[cfg(test)]
@@ -51,68 +72,65 @@ mod tests {
     use crate::{UsdSend, Withdraw3};
     use std::str::FromStr;
 
-    fn get_wallet() -> Result<LocalWallet> {
+    fn get_wallet() -> Result<PrivateKeySigner> {
         let priv_key = "e908f86dbb4d55ac876378565aafeabc187f6690f046459397b17d9b9a19688e";
         priv_key
-            .parse::<LocalWallet>()
-            .map_err(|e| Error::Wallet(e.to_string()))
+            .parse::<PrivateKeySigner>()
+            .map_err(|e| Error::PrivateKeyParse(e.to_string()))
     }
 
-    #[test]
-    fn test_sign_l1_action() -> Result<()> {
+    #[tokio::test]
+    async fn test_sign_l1_action() -> Result<()> {
         let wallet = get_wallet()?;
         let connection_id =
-            H256::from_str("0xde6c4037798a4434ca03cd05f00e3b803126221375cd1e7eaaaf041768be06eb")
+            B256::from_str("0xde6c4037798a4434ca03cd05f00e3b803126221375cd1e7eaaaf041768be06eb")
                 .map_err(|e| Error::GenericParse(e.to_string()))?;
 
-        let expected_mainnet_sig = "fa8a41f6a3fa728206df80801a83bcbfbab08649cd34d9c0bfba7c7b2f99340f53a00226604567b98a1492803190d65a201d6805e5831b7044f17fd530aec7841c";
+        let expected_mainnet_sig = "f88f65c5bf58dac71b4f0fab0e16da760c29e766a1c0970ed4738a9c3c5b1d0d72b3bfc5cbf0e01bd31ffab7c9cfc7f54b0c80532444da8b8ff710074ee9fec31b";
         assert_eq!(
-            sign_l1_action(&wallet, connection_id, true)?.to_string(),
+            sign_l1_action(connection_id, &wallet).await?.to_string(),
             expected_mainnet_sig
-        );
-        let expected_testnet_sig = "1713c0fc661b792a50e8ffdd59b637b1ed172d9a3aa4d801d9d88646710fb74b33959f4d075a7ccbec9f2374a6da21ffa4448d58d0413a0d335775f680a881431c";
-        assert_eq!(
-            sign_l1_action(&wallet, connection_id, false)?.to_string(),
-            expected_testnet_sig
         );
         Ok(())
     }
 
-    #[test]
-    fn test_sign_usd_transfer_action() -> Result<()> {
+    #[tokio::test]
+    async fn test_sign_usd_transfer_action() -> Result<()> {
         let wallet = get_wallet()?;
 
         let usd_send = UsdSend {
-            signature_chain_id: 421614.into(),
-            hyperliquid_chain: "Testnet".to_string(),
-            destination: "0x0D1d9635D0640821d15e323ac8AdADfA9c111414".to_string(),
-            amount: "1".to_string(),
-            time: 1690393044548,
+            signatureChainId: U256::from(421614u64),
+            hyperliquidChain: "Testnet".to_string(),
+            destination: Address::from_str("0x0D1d9635D0640821d15e323ac8AdADfA9c111414")
+                .map_err(|e| Error::GenericParse(e.to_string()))?,
+            amount: U256::from(1u64),
+            time: U256::from(1690393044548u64),
         };
 
-        let expected_sig = "214d507bbdaebba52fa60928f904a8b2df73673e3baba6133d66fe846c7ef70451e82453a6d8db124e7ed6e60fa00d4b7c46e4d96cb2bd61fd81b6e8953cc9d21b";
+        let expected_sig = "c1408a72b086344c3c0837847f60857486c81f9f69c4d05e2cb2a8de027c7bdd2d611524585e82e76eeee31c75ad332bd5d89a91f1cbfa20d039a4e2a77e30bd1c";
         assert_eq!(
-            sign_typed_data(&usd_send, &wallet)?.to_string(),
+            sign_typed_data(&usd_send, &wallet).await?.to_string(),
             expected_sig
         );
         Ok(())
     }
 
-    #[test]
-    fn test_sign_withdraw_from_bridge_action() -> Result<()> {
+    #[tokio::test]
+    async fn test_sign_withdraw_from_bridge_action() -> Result<()> {
         let wallet = get_wallet()?;
 
         let usd_send = Withdraw3 {
-            signature_chain_id: 421614.into(),
-            hyperliquid_chain: "Testnet".to_string(),
-            destination: "0x0D1d9635D0640821d15e323ac8AdADfA9c111414".to_string(),
-            amount: "1".to_string(),
-            time: 1690393044548,
+            signatureChainId: U256::from(421614u64),
+            hyperliquidChain: "Testnet".to_string(),
+            destination: Address::from_str("0x0D1d9635D0640821d15e323ac8AdADfA9c111414")
+                .map_err(|e| Error::GenericParse(e.to_string()))?,
+            amount: U256::from(1u64),
+            time: U256::from(1690393044548u64),
         };
 
-        let expected_sig = "b3172e33d2262dac2b4cb135ce3c167fda55dafa6c62213564ab728b9f9ba76b769a938e9f6d603dae7154c83bf5a4c3ebab81779dc2db25463a3ed663c82ae41c";
+        let expected_sig = "a9c18df3b6321fbcaf685f526a0d9356f5562dfa608f2cddea9081921815a4337050a25f2503bcfa9cf2b724178fa4c52ce705988cf7b71d6c9a1193fdc0afd11c";
         assert_eq!(
-            sign_typed_data(&usd_send, &wallet)?.to_string(),
+            sign_typed_data(&usd_send, &wallet).await?.to_string(),
             expected_sig
         );
         Ok(())

--- a/src/signature/eip712.rs
+++ b/src/signature/eip712.rs
@@ -1,0 +1,57 @@
+use alloy_primitives::{Address, B256, U256};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct Types {
+    pub name: String,
+    pub fields: Vec<Field>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct Field {
+    pub name: String,
+    pub ty: String,
+}
+
+impl Types {
+    pub(crate) fn new() -> Self {
+        Self {
+            name: String::new(),
+            fields: Vec::new(),
+        }
+    }
+
+    pub(crate) fn add_field(&mut self, name: &str, ty: &str) {
+        self.fields.push(Field {
+            name: name.to_string(),
+            ty: ty.to_string(),
+        });
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct Domain {
+    pub name: String,
+    pub version: String,
+    pub chain_id: U256,
+    pub verifying_contract: Option<Address>,
+    pub salt: Option<B256>,
+}
+
+impl Domain {
+    pub(crate) fn new(
+        name: String,
+        version: String,
+        chain_id: U256,
+        verifying_contract: Option<Address>,
+        salt: Option<B256>,
+    ) -> Self {
+        Self {
+            name,
+            version,
+            chain_id,
+            verifying_contract,
+            salt,
+        }
+    }
+} 

--- a/src/signature/mod.rs
+++ b/src/signature/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod agent;
-mod create_signature;
+pub(crate) mod create_signature;
+pub(crate) mod eip712;
 
 pub(crate) use create_signature::{sign_l1_action, sign_typed_data};

--- a/src/ws/sub_structs.rs
+++ b/src/ws/sub_structs.rs
@@ -1,4 +1,4 @@
-use ethers::types::H160;
+use alloy_primitives::Address;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -55,7 +55,7 @@ pub struct TradeInfo {
 #[serde(rename_all = "camelCase")]
 pub struct UserFillsData {
     pub is_snapshot: Option<bool>,
-    pub user: H160,
+    pub user: Address,
     pub fills: Vec<TradeInfo>,
 }
 
@@ -132,7 +132,7 @@ pub struct BasicOrder {
 #[serde(rename_all = "camelCase")]
 pub struct UserFundingsData {
     pub is_snapshot: Option<bool>,
-    pub user: H160,
+    pub user: Address,
     pub fundings: Vec<UserFunding>,
 }
 
@@ -150,7 +150,7 @@ pub struct UserFunding {
 #[serde(rename_all = "camelCase")]
 pub struct UserNonFundingLedgerUpdatesData {
     pub is_snapshot: Option<bool>,
-    pub user: H160,
+    pub user: Address,
     pub non_funding_ledger_updates: Vec<LedgerUpdateData>,
 }
 
@@ -195,16 +195,16 @@ pub struct Withdraw {
 #[derive(Deserialize, Clone, Debug)]
 pub struct InternalTransfer {
     pub usdc: String,
-    pub user: H160,
-    pub destination: H160,
+    pub user: Address,
+    pub destination: Address,
     pub fee: String,
 }
 
 #[derive(Deserialize, Clone, Debug)]
 pub struct SubAccountTransfer {
     pub usdc: String,
-    pub user: H160,
-    pub destination: H160,
+    pub user: Address,
+    pub destination: Address,
 }
 
 #[derive(Deserialize, Clone, Debug)]
@@ -223,15 +223,15 @@ pub struct LiquidatedPosition {
 
 #[derive(Deserialize, Clone, Debug)]
 pub struct VaultDelta {
-    pub vault: H160,
+    pub vault: Address,
     pub usdc: String,
 }
 
 #[derive(Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct VaultWithdraw {
-    pub vault: H160,
-    pub user: H160,
+    pub vault: Address,
+    pub user: Address,
     pub requested_usd: String,
     pub commission: String,
     pub closing_cost: String,
@@ -241,7 +241,7 @@ pub struct VaultWithdraw {
 
 #[derive(Deserialize, Clone, Debug)]
 pub struct VaultLeaderCommission {
-    pub user: H160,
+    pub user: Address,
     pub usdc: String,
 }
 
@@ -258,8 +258,8 @@ pub struct SpotTransfer {
     pub token: String,
     pub amount: String,
     pub usdc_value: String,
-    pub user: H160,
-    pub destination: H160,
+    pub user: Address,
+    pub destination: Address,
     pub fee: String,
 }
 
@@ -277,7 +277,7 @@ pub struct NotificationData {
 #[derive(Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct WebData2Data {
-    pub user: H160,
+    pub user: Address,
 }
 
 #[derive(Deserialize, Clone, Debug)]

--- a/src/ws/ws_manager.rs
+++ b/src/ws/ws_manager.rs
@@ -4,6 +4,7 @@ use crate::{
     ActiveAssetCtx, Error, Notification, UserFills, UserFundings, UserNonFundingLedgerUpdates,
     WebData2,
 };
+use alloy_primitives::Address;
 use futures_util::{stream::SplitSink, SinkExt, StreamExt};
 use log::{error, info, warn};
 use serde::{Deserialize, Serialize};
@@ -29,8 +30,6 @@ use tokio_tungstenite::{
     MaybeTlsStream, WebSocketStream,
 };
 
-use ethers::types::H160;
-
 #[derive(Debug)]
 struct SubscriptionData {
     sending_channel: UnboundedSender<Message>,
@@ -51,16 +50,16 @@ pub(crate) struct WsManager {
 #[serde(rename_all = "camelCase")]
 pub enum Subscription {
     AllMids,
-    Notification { user: H160 },
-    WebData2 { user: H160 },
+    Notification { user: Address },
+    WebData2 { user: Address },
     Candle { coin: String, interval: String },
     L2Book { coin: String },
     Trades { coin: String },
-    OrderUpdates { user: H160 },
-    UserEvents { user: H160 },
-    UserFills { user: H160 },
-    UserFundings { user: H160 },
-    UserNonFundingLedgerUpdates { user: H160 },
+    OrderUpdates { user: Address },
+    UserEvents { user: Address },
+    UserFills { user: Address },
+    UserFundings { user: Address },
+    UserNonFundingLedgerUpdates { user: Address },
     ActiveAssetCtx { coin: String },
 }
 


### PR DESCRIPTION
Alloy is preferred by many to ethers with more modern macros and a robust typeset. Paradigm spends significant effort to maintain alloy as well so it wont be abandoned.