### PR TITLE
adding the proper signature type for ApproveBuilderFee

### DIFF
--- a/src/bin/approve_builder_fee.rs
+++ b/src/bin/approve_builder_fee.rs
@@ -1,4 +1,4 @@
-use ethers::signers::LocalWallet;
+use ethers::{signers::LocalWallet, types::H160};
 use hyperliquid_rust_sdk::{BaseUrl, ExchangeClient};
 use log::info;
 
@@ -16,10 +16,10 @@ async fn main() {
             .unwrap();
 
     let max_fee_rate = "0.1%";
-    let builder = "0x1ab189B7801140900C711E458212F9c76F8dAC79".to_lowercase();
+    let builder = H160::from_str("0x1ab189B7801140900C711E458212F9c76F8dAC79").unwrap();
 
     let resp = exchange_client
-        .approve_builder_fee(builder.to_string(), max_fee_rate.to_string(), Some(&wallet))
+        .approve_builder_fee(builder, max_fee_rate.to_string(), Some(&wallet))
         .await;
     info!("resp: {resp:#?}");
 }

--- a/src/exchange/exchange_client.rs
+++ b/src/exchange/exchange_client.rs
@@ -731,7 +731,7 @@ impl ExchangeClient {
 
     pub async fn approve_builder_fee(
         &self,
-        builder: String,
+        builder: H160,
         max_fee_rate: String,
         wallet: Option<&LocalWallet>,
     ) -> Result<ExchangeResponseStatus> {
@@ -744,19 +744,16 @@ impl ExchangeClient {
             "Testnet".to_string()
         };
 
-        let action = Actions::ApproveBuilderFee(ApproveBuilderFee {
+        let approve_builder_fee = ApproveBuilderFee {
             signature_chain_id: 421614.into(),
             hyperliquid_chain,
             builder,
             max_fee_rate,
             nonce: timestamp,
-        });
-
-        let connection_id = action.hash(timestamp, self.vault_address)?;
-        let action = serde_json::to_value(&action).map_err(|e| Error::JsonParse(e.to_string()))?;
-
-        let is_mainnet = self.http_client.is_mainnet();
-        let signature = sign_l1_action(wallet, connection_id, is_mainnet)?;
+        };
+        let signature = sign_typed_data(&approve_builder_fee, wallet)?;
+        let action = serde_json::to_value(Actions::ApproveBuilderFee(approve_builder_fee))
+            .map_err(|e| Error::JsonParse(e.to_string()))?;
         self.post(action, signature, timestamp).await
     }
 }


### PR DESCRIPTION
hey, 
according to the python sdk the builder fee has a custom signature (implemented [here](https://github.com/hyperliquid-dex/hyperliquid-python-sdk/blob/b569b18bdb923f6e84a61c164ccb29e51f3e181b/hyperliquid/utils/signing.py#L345-L357))

the current implementation is throwing the following error:
```
Must deposit before performing actions. User:  0x......
```
my implmentation fixes this, now it matches the [function](https://github.com/hyperliquid-dex/hyperliquid-python-sdk/blob/b569b18bdb923f6e84a61c164ccb29e51f3e181b/hyperliquid/exchange.py#L549-L554) from the python sdk

if it looks good, let me know and I will add tests too

thanks