### PR TITLE
Fix issue #88

### DIFF
--- a/src/bin/ws_spot_price.rs
+++ b/src/bin/ws_spot_price.rs
@@ -1,0 +1,33 @@
+use std::time::Duration;
+
+use hyperliquid_rust_sdk::{BaseUrl, InfoClient, Message, Subscription};
+use log::info;
+use tokio::{spawn, sync::mpsc::unbounded_channel, time::sleep};
+
+#[tokio::main]
+async fn main() {
+    env_logger::init();
+    let mut info_client = InfoClient::new(None, Some(BaseUrl::Mainnet)).await.unwrap();
+
+    let (sender, mut receiver) = unbounded_channel();
+    let subscription_id = info_client
+        .subscribe(
+            Subscription::ActiveAssetCtx {
+                coin: "@107".to_string(), //spot index for hype token
+            },
+            sender,
+        )
+        .await
+        .unwrap();
+
+    spawn(async move {
+        sleep(Duration::from_secs(30)).await;
+        info!("Unsubscribing from order updates data");
+        info_client.unsubscribe(subscription_id).await.unwrap()
+    });
+
+    // this loop ends when we unsubscribe
+    while let Some(Message::ActiveSpotAssetCtx(order_updates)) = receiver.recv().await {
+        info!("Received order update data: {order_updates:?}");
+    }
+}

--- a/src/ws/message_types.rs
+++ b/src/ws/message_types.rs
@@ -60,3 +60,8 @@ pub struct WebData2 {
 pub struct ActiveAssetCtx {
     pub data: ActiveAssetCtxData,
 }
+
+#[derive(Deserialize, Clone, Debug)]
+pub struct ActiveSpotAssetCtx {
+    pub data: ActiveSpotAssetCtxData,
+}

--- a/src/ws/sub_structs.rs
+++ b/src/ws/sub_structs.rs
@@ -314,6 +314,13 @@ pub struct PerpsAssetCtx {
     pub oracle_px: String,
 }
 
+#[derive(Deserialize, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct ActiveSpotAssetCtxData {
+    pub coin: String,
+    pub ctx: SpotAssetCtx,
+}
+
 #[derive(Deserialize, Serialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct SpotAssetCtx {

--- a/src/ws/ws_manager.rs
+++ b/src/ws/ws_manager.rs
@@ -31,6 +31,8 @@ use tokio_tungstenite::{
 
 use ethers::types::H160;
 
+use super::ActiveSpotAssetCtx;
+
 #[derive(Debug)]
 struct SubscriptionData {
     sending_channel: UnboundedSender<Message>,
@@ -83,6 +85,7 @@ pub enum Message {
     Notification(Notification),
     WebData2(WebData2),
     ActiveAssetCtx(ActiveAssetCtx),
+    ActiveSpotAssetCtx(ActiveSpotAssetCtx),
     Pong,
 }
 
@@ -266,6 +269,13 @@ impl WsManager {
                     coin: active_asset_ctx.data.coin.clone(),
                 })
                 .map_err(|e| Error::JsonParse(e.to_string()))
+            }
+            Message::ActiveSpotAssetCtx(active_spot_asset_ctx) => {
+                let s = serde_json::to_string(&Subscription::ActiveAssetCtx {
+                    coin: active_spot_asset_ctx.data.coin.clone(),
+                })
+                .map_err(|e| Error::JsonParse(e.to_string()));
+                s
             }
             Message::SubscriptionResponse | Message::Pong => Ok(String::default()),
             Message::NoData => Ok("".to_string()),


### PR DESCRIPTION
Handle activeAssetCtx websocket connections for spot assets not being able to be parsed due to incoming channel type being activeSpotAssetCtx.