### PR TITLE
fix: vault_transfer type error

### DIFF
--- a/src/bin/vault_transfer.rs
+++ b/src/bin/vault_transfer.rs
@@ -14,13 +14,13 @@ async fn main() {
         .await
         .unwrap();
 
-    let usd = "1"; // 1 USD
+    let usd = 5_000_000; // at least 5 USD
     let is_deposit = true;
 
     let res = exchange_client
         .vault_transfer(
             is_deposit,
-            usd.to_string(),
+            usd,
             Some(
                 "0x1962905b0a2d0ce7907ae1a0d17f3e4a1f63dfb7"
                     .parse()

--- a/src/exchange/actions.rs
+++ b/src/exchange/actions.rs
@@ -287,7 +287,7 @@ pub struct ClassTransfer {
 pub struct VaultTransfer {
     pub vault_address: H160,
     pub is_deposit: bool,
-    pub usd: String,
+    pub usd: u64,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/src/exchange/exchange_client.rs
+++ b/src/exchange/exchange_client.rs
@@ -203,7 +203,7 @@ impl ExchangeClient {
     pub async fn vault_transfer(
         &self,
         is_deposit: bool,
-        usd: String,
+        usd: u64,
         vault_address: Option<H160>,
         wallet: Option<&LocalWallet>,
     ) -> Result<ExchangeResponseStatus> {


### PR DESCRIPTION
request `usd` type is number