### PR TITLE
Add fee_token to TradeInfo

### DIFF
--- a/src/ws/sub_structs.rs
+++ b/src/ws/sub_structs.rs
@@ -48,6 +48,7 @@ pub struct TradeInfo {
     pub cloid: Option<String>,
     pub crossed: bool,
     pub fee: String,
+    pub fee_token: String,
     pub tid: u64,
 }
 


### PR DESCRIPTION
# Description

Add missing `fee_token` field to `TradeInfo` [ref](https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/websocket/subscriptions)

# Test Plan

Tested locally with `RUST_LOG=info cargo run --bin ws_user_events` on a mainnet account