### PR TITLE
Update sub_structs.rs to add missing users field in Trade struct

### DIFF
--- a/src/ws/sub_structs.rs
+++ b/src/ws/sub_structs.rs
@@ -11,6 +11,7 @@ pub struct Trade {
     pub time: u64,
     pub hash: String,
     pub tid: u64,
+    pub users: (String, String),
 }
 
 #[derive(Deserialize, Clone, Debug)]


### PR DESCRIPTION
Hello

As per the doc at https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/websocket/subscriptions, the websocket trade response is as following

```
interface WsTrade {
  coin: string;
  side: string;
  px: string;
  sz: string;
  hash: string;
  time: number;
  // tid is 53-bit hash of (buyer_oid, seller_oid). 
  // For a globally unique trade id, use (block_time, coin, tid)
  tid: number;  
  users: [string, string] // [buyer, seller]
}
```

But the `users` field is missing from the struct in the SDK.