### PR TITLE
Shrink the `Error` enum size

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -7,8 +7,8 @@ pub enum Error {
     ClientRequest {
         status_code: u16,
         error_code: Option<u16>,
-        error_message: String,
-        error_data: Option<String>,
+        error_message: Box<str>,
+        error_data: Option<Box<str>>,
     },
     #[error("Server error: status code: {status_code}, error message: {error_message}")]
     ServerRequest {

--- a/src/req.rs
+++ b/src/req.rs
@@ -31,14 +31,14 @@ async fn parse_response(response: Response) -> Result<String> {
             Ok(error_data) => Error::ClientRequest {
                 status_code,
                 error_code: Some(error_data.code),
-                error_message: error_data.msg,
-                error_data: Some(error_data.data),
+                error_message: error_data.msg.into(),
+                error_data: Some(error_data.data.into()),
             },
             Err(err) => Error::ClientRequest {
                 status_code,
-                error_message: text,
+                error_message: text.into(),
                 error_code: None,
-                error_data: Some(err.to_string()),
+                error_data: Some(err.to_string().into()),
             },
         };
         return Err(client_error);


### PR DESCRIPTION
A large enum used in several places can cause a negative runtime impact. In fact, this is so common that the community created several lints to prevent such a scenario.

- [large_enum_variant](https://rust-lang.github.io/rust-clippy/master/?groups=perf#large_enum_variant)
- [result_large_err](https://rust-lang.github.io/rust-clippy/master/?groups=perf#result_large_err)
- [variant_size_differences](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_lint/types/static.VARIANT_SIZE_DIFFERENCES.html)

This PR cuts **16 bytes** from the `Error` enum through the use of `Box<str>` instead of `String` in the largest variant, which doesn't change any intended behavior.