### PR TITLE
fix: Return current timestamp when nonce lags

### DIFF
--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -19,7 +19,8 @@ pub(crate) fn next_nonce() -> u64 {
     }
     // more than 300 seconds behind
     if nonce + 300000 < now_ms {
-        CUR_NONCE.fetch_max(now_ms, Ordering::Relaxed);
+        CUR_NONCE.fetch_max(now_ms + 1, Ordering::Relaxed);
+        return now_ms;
     }
     nonce
 }


### PR DESCRIPTION
The function `next_nonce()` always returns a unique nonce, by storing the current timestamp in a static variable and incrementing it before returning. However, this variable can lag during times of inactivity. Though there is a check that handles it by updating it, it ends with returning the old nonce, which fails the current call.