### PR TITLE
Add in Evm User Modify method for exchange client

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"

--- a/src/bin/using_big_blocks.rs
+++ b/src/bin/using_big_blocks.rs
@@ -1,0 +1,22 @@
+use ethers::signers::LocalWallet;
+use hyperliquid_rust_sdk::{BaseUrl, ExchangeClient};
+use log::info;
+
+#[tokio::main]
+async fn main() {
+    env_logger::init();
+    // Key was randomly generated for testing and shouldn't be used with any real funds
+    let wallet: LocalWallet = "e908f86dbb4d55ac876378565aafeabc187f6690f046459397b17d9b9a19688e"
+        .parse()
+        .unwrap();
+
+    let exchange_client = ExchangeClient::new(None, wallet.clone(), Some(BaseUrl::Testnet), None, None)
+        .await
+        .unwrap();
+
+    let res = exchange_client
+        .enable_big_blocks(false, Some(&wallet))
+        .await
+        .unwrap();
+    info!("enable big blocks : {res:?}");
+}

--- a/src/exchange/actions.rs
+++ b/src/exchange/actions.rs
@@ -298,6 +298,13 @@ pub struct SetReferrer {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
+pub struct EvmUserModify {
+    pub using_big_blocks: bool,
+}
+
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct ApproveBuilderFee {
     pub max_fee_rate: String,
     pub builder: String,


### PR DESCRIPTION
- currently the rust sdk lags the python sdk for quite a few endpoints w/ evm user modify being especially painful
- simple PR adds in the user modify method for big blocks on HL EVM
- this has been tested live and works for HL mainnet