### PR TITLE
Fix BasicOrderInfo 

### DIFF
--- a/src/info/sub_structs.rs
+++ b/src/info/sub_structs.rs
@@ -141,7 +141,7 @@ pub struct BasicOrderInfo {
     pub reduce_only: bool,
     pub order_type: String,
     pub orig_sz: String,
-    pub tif: String,
+    pub tif: Option<String>,
     pub cloid: Option<String>,
 }
 


### PR DESCRIPTION
Adding the right type to BasicOrderInfo

````
pub struct BasicOrderInfo {
    pub coin: String,
    pub side: String,
    pub limit_px: String,
    pub sz: String,
    pub oid: u64,
    pub timestamp: u64,
    pub trigger_condition: String,
    pub is_trigger: bool,
    pub trigger_px: String,
    pub is_position_tpsl: bool,
    pub reduce_only: bool,
    pub order_type: String,
    pub orig_sz: String,
    pub tif: Option<String>,
    pub cloid: Option<String>,
}
````