### PR TITLE
Fix some mandatory fields are actually optional in API

### DIFF
--- a/src/meta.rs
+++ b/src/meta.rs
@@ -75,12 +75,12 @@ pub struct SpotAssetContext {
 pub struct AssetContext {
     pub day_ntl_vlm: String,
     pub funding: String,
-    pub impact_pxs: Vec<String>,
+    pub impact_pxs: Option<Vec<String>>,
     pub mark_px: String,
     pub mid_px: Option<String>,
     pub open_interest: String,
     pub oracle_px: String,
-    pub premium: String,
+    pub premium: Option<String>,
     pub prev_day_px: String,
 }
 


### PR DESCRIPTION
Some fields (`premium` and `impact_pxs`) can be `null` in `meta_and_asset_ctxs` request, which causes meta_and_asset_contexts to fail (both on Testnet and Mainnet):

```
thread 'main' panicked at src/bin/info.rs:97:53:
called `Result::unwrap()` on an `Err` value: JsonParse("invalid type: null, expected a string at line 1 column 14917")
stack backtrace:
   0: __rustc::rust_begin_unwind
             at /rustc/0060d5a2a8a86a31f6299311fe64b1d755a91c4f/library/std/src/panicking.rs:697:5
   1: core::panicking::panic_fmt
             at /rustc/0060d5a2a8a86a31f6299311fe64b1d755a91c4f/library/core/src/panicking.rs:75:14
   2: core::result::unwrap_failed
             at /rustc/0060d5a2a8a86a31f6299311fe64b1d755a91c4f/library/core/src/result.rs:1852:5
   3: core::result::Result<T,E>::unwrap
             at /Users/konstantinfastov/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/result.rs:1223:23
   4: info::meta_and_asset_contexts_example::{{closure}}
             at ./src/bin/info.rs:97:53
   5: info::main::{{closure}}
             at ./src/bin/info.rs:16:51
   6: tokio::runtime::park::CachedParkThread::block_on::{{closure}}
             at /Users/konstantinfastov/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/park.rs:285:71
   7: tokio::task::coop::with_budget
             at /Users/konstantinfastov/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/task/coop/mod.rs:167:5
   8: tokio::task::coop::budget
             at /Users/konstantinfastov/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/task/coop/mod.rs:133:5
   9: tokio::runtime::park::CachedParkThread::block_on
             at /Users/konstantinfastov/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/park.rs:285:31
  10: tokio::runtime::context::blocking::BlockingRegionGuard::block_on
             at /Users/konstantinfastov/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/context/blocking.rs:66:14
  11: tokio::runtime::scheduler::multi_thread::MultiThread::block_on::{{closure}}
             at /Users/konstantinfastov/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/scheduler/multi_thread/mod.rs:87:22
  12: tokio::runtime::context::runtime::enter_runtime
             at /Users/konstantinfastov/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/context/runtime.rs:65:16
  13: tokio::runtime::scheduler::multi_thread::MultiThread::block_on
             at /Users/konstantinfastov/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/scheduler/multi_thread/mod.rs:86:9
  14: tokio::runtime::runtime::Runtime::block_on_inner
             at /Users/konstantinfastov/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/runtime.rs:358:50
  15: tokio::runtime::runtime::Runtime::block_on
             at /Users/konstantinfastov/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/runtime.rs:330:18
  16: info::main
             at ./src/bin/info.rs:29:50
  17: core::ops::function::FnOnce::call_once
             at /Users/konstantinfastov/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/ops/function.rs:253:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```

I've made those fields optional to allow the code to correctly process both null and non-null cases.