### PR TITLE
Add tid, fee_token, and optional twap_id to UserFillsResponse struct

### DIFF
--- a/src/info/response_structs.rs
+++ b/src/info/response_structs.rs
@@ -56,6 +56,9 @@ pub struct UserFillsResponse {
     pub sz: String,
     pub time: u64,
     pub fee: String,
+    pub tid: u64,
+    pub fee_token: String,
+    pub twap_id: Option<u64>,
 }
 
 #[derive(serde::Deserialize, Debug)]


### PR DESCRIPTION
`tid` and `fee_token` is mentioned in documentation:
https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/info-endpoint#retrieve-a-users-fills
`twapId` is used in real API responses to `userFills` request, for example:
```
{
    "coin": "PROMPT",
    "px": "0.1248",
    "sz": "85.0",
    "side": "B",
    "time": 1755175396872,
    "startPosition": "0.0",
    "dir": "Open Long",
    "closedPnl": "0.0",
    "hash": "0x7ff74870217f75c5d0600429836e010207c300ae0ae720e784aabe3c69287ce8",
    "oid": 134097425282,
    "crossed": true,
    "fee": "0.004773",
    "tid": 1013434298226853,
    "feeToken": "USDC",
    "twapId": null
}
```