### PR TITLE
Add claim rewards action support

### DIFF
--- a/src/bin/claim_rewards.rs
+++ b/src/bin/claim_rewards.rs
@@ -1,0 +1,28 @@
+use alloy::signers::local::PrivateKeySigner;
+use hyperliquid_rust_sdk::{BaseUrl, ExchangeClient, ExchangeResponseStatus};
+use log::info;
+
+#[tokio::main]
+async fn main() {
+    env_logger::init();
+    // Key was randomly generated for testing and shouldn't be used with any real funds
+    let wallet: PrivateKeySigner =
+        "e908f86dbb4d55ac876378565aafeabc187f6690f046459397b17d9b9a19688e"
+            .parse()
+            .unwrap();
+
+    let exchange_client = ExchangeClient::new(None, wallet, Some(BaseUrl::Testnet), None, None)
+        .await
+        .unwrap();
+
+    let response = exchange_client.claim_rewards(None).await.unwrap();
+
+    match response {
+        ExchangeResponseStatus::Ok(exchange_response) => {
+            info!("Rewards claimed successfully: {:?}", exchange_response);
+        }
+        ExchangeResponseStatus::Err(e) => {
+            info!("Failed to claim rewards: {}", e);
+        }
+    }
+}

--- a/src/exchange/actions.rs
+++ b/src/exchange/actions.rs
@@ -235,6 +235,10 @@ pub struct ScheduleCancel {
     pub time: Option<u64>,
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ClaimRewards {}
+
 impl Eip712 for ApproveBuilderFee {
     fn domain(&self) -> Eip712Domain {
         eip_712_domain(self.signature_chain_id)

--- a/src/exchange/actions.rs
+++ b/src/exchange/actions.rs
@@ -237,7 +237,7 @@ pub struct ScheduleCancel {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
-pub struct ClaimRewards {}
+pub struct ClaimRewards;
 
 impl Eip712 for ApproveBuilderFee {
     fn domain(&self) -> Eip712Domain {


### PR DESCRIPTION
## Summary
- Added `ClaimRewards` struct for claiming referral and affiliate rewards
- Implemented `claim_rewards()` method in ExchangeClient
- Added unit tests and usage example