### PR TITLE
add missing fields for userFees response

### DIFF
--- a/src/info/response_structs.rs
+++ b/src/info/response_structs.rs
@@ -7,7 +7,8 @@ use crate::{
     ActiveStakingDiscount, DailyUserVlm, Delta, FeeSchedule, Leverage, OrderInfo, Referrer,
     ReferrerState, StakingLink, UserTokenBalance,
 };
-use serde_json::Value;
+// NOTE: Docs mention a trial field, but its format is unclear and we have not
+// observed it in practice. Omitting the field for now to avoid guessing.
 
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
@@ -33,7 +34,6 @@ pub struct UserFeesResponse {
     pub user_cross_rate: String,
     pub user_spot_cross_rate: String,
     pub user_spot_add_rate: String,
-    pub trial: Option<Value>,
     pub fee_trial_reward: String,
     pub next_trial_available_timestamp: Option<u64>,
     pub staking_link: Option<StakingLink>,

--- a/src/info/response_structs.rs
+++ b/src/info/response_structs.rs
@@ -4,9 +4,10 @@ use alloy::primitives::Address;
 
 use crate::{
     info::{AssetPosition, Level, MarginSummary},
-    DailyUserVlm, Delta, FeeSchedule, Leverage, OrderInfo, Referrer, ReferrerState,
-    UserTokenBalance,
+    ActiveStakingDiscount, DailyUserVlm, Delta, FeeSchedule, Leverage, OrderInfo, Referrer,
+    ReferrerState, StakingLink, UserTokenBalance,
 };
+use serde_json::Value;
 
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
@@ -30,6 +31,13 @@ pub struct UserFeesResponse {
     pub fee_schedule: FeeSchedule,
     pub user_add_rate: String,
     pub user_cross_rate: String,
+    pub user_spot_cross_rate: String,
+    pub user_spot_add_rate: String,
+    pub trial: Option<Value>,
+    pub fee_trial_reward: String,
+    pub next_trial_available_timestamp: Option<u64>,
+    pub staking_link: Option<StakingLink>,
+    pub active_staking_discount: ActiveStakingDiscount,
 }
 
 #[derive(serde::Deserialize, Debug)]

--- a/src/info/response_structs.rs
+++ b/src/info/response_structs.rs
@@ -5,10 +5,9 @@ use alloy::primitives::Address;
 use crate::{
     info::{AssetPosition, Level, MarginSummary},
     ActiveStakingDiscount, DailyUserVlm, Delta, FeeSchedule, Leverage, OrderInfo, Referrer,
-    ReferrerState, StakingLink, UserTokenBalance,
+    ReferrerState, StakingLink, TrialInfo, UserTokenBalance,
 };
-// NOTE: Docs mention a trial field, but its format is unclear and we have not
-// observed it in practice. Omitting the field for now to avoid guessing.
+// NOTE: The `trial` field appears but the schema is undocumented; capture it as raw JSON for now.
 
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
@@ -34,6 +33,8 @@ pub struct UserFeesResponse {
     pub user_cross_rate: String,
     pub user_spot_cross_rate: String,
     pub user_spot_add_rate: String,
+    #[serde(default)]
+    pub trial: Option<TrialInfo>,
     pub fee_trial_reward: String,
     pub next_trial_available_timestamp: Option<u64>,
     pub staking_link: Option<StakingLink>,

--- a/src/info/sub_structs.rs
+++ b/src/info/sub_structs.rs
@@ -123,14 +123,14 @@ pub struct UserTokenBalance {
 }
 
 #[derive(Deserialize, Debug, Clone)]
-#[serde(tag = "type", rename_all = "camelCase")]
-pub enum StakingLink {
-    // {"type":"stakingUser","tradingUser":"0x..."}
-    StakingUser { trading_user: String },
-    // {"type":"tradingUser","stakingUser":"0x..."}
-    TradingUser { staking_user: String },
-    // {"type":"requested","stakingUser":"0x..."}
-    Requested { staking_user: String },
+#[serde(rename_all = "camelCase")]
+pub struct StakingLink {
+    #[serde(rename = "type")]
+    pub link_type: String,
+    #[serde(default)]
+    pub staking_user: Option<String>,
+    #[serde(default)]
+    pub trading_user: Option<String>,
 }
 
 #[derive(Deserialize, Debug)]

--- a/src/info/sub_structs.rs
+++ b/src/info/sub_structs.rs
@@ -83,7 +83,10 @@ pub struct DailyUserVlm {
 pub struct FeeSchedule {
     pub add: String,
     pub cross: String,
+    pub spot_cross: String,
+    pub spot_add: String,
     pub referral_discount: String,
+    pub staking_discount_tiers: Vec<StakingDiscountTier>,
     pub tiers: Tiers,
 }
 
@@ -105,6 +108,8 @@ pub struct Mm {
 pub struct Vip {
     pub add: String,
     pub cross: String,
+    pub spot_cross: String,
+    pub spot_add: String,
     pub ntl_cutoff: String,
 }
 
@@ -115,6 +120,28 @@ pub struct UserTokenBalance {
     pub hold: String,
     pub total: String,
     pub entry_ntl: String,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct StakingLink {
+    #[serde(rename = "type")]
+    pub link_type: String,
+    pub staking_user: String,
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct StakingDiscountTier {
+    pub bps_of_max_supply: String,
+    pub discount: String,
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct ActiveStakingDiscount {
+    pub bps_of_max_supply: String,
+    pub discount: String,
 }
 
 #[derive(Deserialize, Clone, Debug)]

--- a/src/info/sub_structs.rs
+++ b/src/info/sub_structs.rs
@@ -1,5 +1,6 @@
 use alloy::primitives::Address;
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
@@ -146,6 +147,9 @@ pub struct ActiveStakingDiscount {
     pub bps_of_max_supply: String,
     pub discount: String,
 }
+
+/// The API exposes a `trial` object whose schema is not yet documented; capture it raw for now.
+pub type TrialInfo = Value;
 
 #[derive(Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]

--- a/src/info/sub_structs.rs
+++ b/src/info/sub_structs.rs
@@ -123,11 +123,14 @@ pub struct UserTokenBalance {
 }
 
 #[derive(Deserialize, Debug, Clone)]
-#[serde(rename_all = "camelCase")]
-pub struct StakingLink {
-    #[serde(rename = "type")]
-    pub link_type: String,
-    pub staking_user: String,
+#[serde(tag = "type", rename_all = "camelCase")]
+pub enum StakingLink {
+    // {"type":"stakingUser","tradingUser":"0x..."}
+    StakingUser { trading_user: String },
+    // {"type":"tradingUser","stakingUser":"0x..."}
+    TradingUser { staking_user: String },
+    // {"type":"requested","stakingUser":"0x..."}
+    Requested { staking_user: String },
 }
 
 #[derive(Deserialize, Debug)]


### PR DESCRIPTION
## Summary
- extend `FeeSchedule` with spot maker/taker rates and staking discount tiers returned by `/info`
- surface `stakingLink`, `activeStakingDiscount`, and related fields on `UserFeesResponse`
- capture the undocumented `trial` payload as raw JSON so the SDK stops dropping it

## Validation
- cargo test
- curl https://api.hyperliquid.xyz/info -H 'Content-Type: application/json' \
  -d '{"type":"userFees","user":"0x0a0000000000000000000000000000000000000a"}'
