### PR TITLE
Remove unused dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,12 +17,12 @@ alloy = { version = "1.0", default-features = false, features = [
   "sol-types",
   "signer-local",
 ] }
-chrono = "0.4.26"
+chrono = { default-features = false, features = ["now"], version = "0.4.26" }
 env_logger = "0.11.8"
-futures-util = "0.3.28"
+futures-util = { default-features = false, version = "0.3.28" }
 lazy_static = "1.0"
 log = "0.4.19"
-reqwest = "0.12.19"
+reqwest = { default-features = false, version = "0.12.19" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 rmp-serde = "1.0"


### PR DESCRIPTION
Some dependencies were bringing unnecessary transients, as such, they were removed through the use of `default-features = false`. AFAICT, everything is compiling and no already established behavior was modified.

`cargo check` goes from 328 dependencies to 318 dependencies reducing the compilation time from ~20s to ~19s.