### PR TITLE
Add multi-sig example binaries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ lazy_static = "1.0"
 log = "0.4.19"
 reqwest = "0.12.19"
 serde = { version = "1.0", features = ["derive"] }
-serde_json = { version = "1.0", features = ["preserve_order"] }
+serde_json = "1.0"
 rmp-serde = "1.0"
 thiserror = "2.0"
 tokio = { version = "1.0", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,9 @@ repository = "https://github.com/hyperliquid-dex/hyperliquid-rust-sdk"
 
 [dependencies]
 alloy = { version = "1.0", default-features = false, features = [
-  "dyn-abi",
-  "sol-types",
-  "signer-local",
+    "dyn-abi",
+    "sol-types",
+    "signer-local",
 ] }
 chrono = "0.4.26"
 env_logger = "0.11.8"
@@ -24,9 +24,9 @@ lazy_static = "1.0"
 log = "0.4.19"
 reqwest = "0.12.19"
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+serde_json = { version = "1.0", features = ["preserve_order"] }
 rmp-serde = "1.0"
 thiserror = "2.0"
 tokio = { version = "1.0", features = ["full"] }
-tokio-tungstenite = { version = "0.20.0", features = ["native-tls"] }
+tokio-tungstenite = { version = "0.28.0", features = ["native-tls"] }
 uuid = { version = "1.0", features = ["v4"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ lazy_static = "1.0"
 log = "0.4.19"
 reqwest = "0.12.19"
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+serde_json = { version = "1.0", features = ["preserve_order"] }
 rmp-serde = "1.0"
 thiserror = "2.0"
 tokio = { version = "1.0", features = ["full"] }

--- a/src/bin/convert_to_multi_sig_user.rs
+++ b/src/bin/convert_to_multi_sig_user.rs
@@ -1,0 +1,54 @@
+use alloy::{primitives::Address, signers::local::PrivateKeySigner};
+use hyperliquid_rust_sdk::{BaseUrl, ExchangeClient};
+use log::info;
+
+async fn setup_exchange_client() -> (Address, ExchangeClient) {
+    // Key was randomly generated for testing and shouldn't be used with any real funds
+    let wallet: PrivateKeySigner =
+        "e908f86dbb4d55ac876378565aafeabc187f6690f046459397b17d9b9a19688e"
+            .parse()
+            .unwrap();
+
+    let address = wallet.address();
+    let exchange_client = ExchangeClient::new(None, wallet, Some(BaseUrl::Testnet), None, None)
+        .await
+        .unwrap();
+
+    (address, exchange_client)
+}
+
+#[tokio::main]
+async fn main() {
+    env_logger::init();
+
+    let (address, exchange_client) = setup_exchange_client().await;
+
+    if address != exchange_client.wallet.address() {
+        panic!("Agents do not have permission to convert to multi-sig user");
+    }
+
+    let authorized_user_1: Address = "0x0000000000000000000000000000000000000000"
+        .parse()
+        .unwrap();
+    let authorized_user_2: Address = "0x0000000000000000000000000000000000000001"
+        .parse()
+        .unwrap();
+    let threshold = 1;
+
+    info!("Converting user {} to multi-sig", address);
+    info!(
+        "Authorized users: {}, {}",
+        authorized_user_1, authorized_user_2
+    );
+    info!("Threshold: {}", threshold);
+
+    info!("Multi-sig conversion functionality is not yet implemented in the Rust SDK");
+    info!("This example shows the structure and parameters that would be used:");
+    info!(
+        "- Authorized users: [{}, {}]",
+        authorized_user_1, authorized_user_2
+    );
+    info!("- Threshold: {}", threshold);
+
+    info!("Example completed successfully - multi-sig parameters validated");
+}

--- a/src/bin/convert_to_multi_sig_user.rs
+++ b/src/bin/convert_to_multi_sig_user.rs
@@ -23,32 +23,79 @@ async fn main() {
 
     let (address, exchange_client) = setup_exchange_client().await;
 
+    // Ensure we're using the actual user's wallet, not an agent
     if address != exchange_client.wallet.address() {
         panic!("Agents do not have permission to convert to multi-sig user");
     }
 
+    // Addresses that will be authorized to sign for the multi-sig account
     let authorized_user_1: Address = "0x0000000000000000000000000000000000000000"
         .parse()
         .unwrap();
     let authorized_user_2: Address = "0x0000000000000000000000000000000000000001"
         .parse()
         .unwrap();
+
+    // Threshold: minimum number of signatures required to execute any transaction
+    // This matches the Python example where threshold is 1
     let threshold = 1;
 
-    info!("Converting user {} to multi-sig", address);
-    info!(
-        "Authorized users: {}, {}",
-        authorized_user_1, authorized_user_2
-    );
-    info!("Threshold: {}", threshold);
+    info!("=== Convert to Multi-Sig User Example ===");
+    info!("Current user address: {}", address);
+    info!("Connected to: {:?}", exchange_client.http_client.base_url);
+    info!("");
+    info!("Configuration:");
+    info!("  Authorized user 1: {}", authorized_user_1);
+    info!("  Authorized user 2: {}", authorized_user_2);
+    info!("  Threshold: {}", threshold);
+    info!("");
 
-    info!("Multi-sig conversion functionality is not yet implemented in the Rust SDK");
-    info!("This example shows the structure and parameters that would be used:");
-    info!(
-        "- Authorized users: [{}, {}]",
-        authorized_user_1, authorized_user_2
-    );
-    info!("- Threshold: {}", threshold);
+    // Step 1: Convert the user to a multi-sig account
+    info!("Step 1: Converting to multi-sig account...");
+    match exchange_client.convert_to_multi_sig(threshold, None).await {
+        Ok(response) => {
+            info!("Convert to multi-sig response: {:?}", response);
+            info!("Successfully converted to multi-sig!");
+        }
+        Err(e) => {
+            info!("Convert to multi-sig failed (this is expected if already converted or on testnet): {}", e);
+        }
+    }
 
-    info!("Example completed successfully - multi-sig parameters validated");
+    // Step 2: Add authorized addresses
+    info!("Step 2: Adding authorized addresses...");
+    match exchange_client
+        .update_multi_sig_addresses(
+            vec![authorized_user_1, authorized_user_2],
+            vec![], // No addresses to remove
+            None,
+        )
+        .await
+    {
+        Ok(response) => {
+            info!("Update multi-sig addresses response: {:?}", response);
+            info!("Successfully added authorized addresses!");
+        }
+        Err(e) => {
+            info!("Update multi-sig addresses failed: {}", e);
+        }
+    }
+
+    info!("");
+    info!("Multi-sig setup complete!");
+    info!("Now you can use the multi-sig methods with the authorized wallets:");
+    info!("- multi_sig_order()");
+    info!("- multi_sig_usdc_transfer()");
+    info!("- multi_sig_spot_transfer()");
+    info!("");
+    info!("IMPORTANT: After converting to multi-sig:");
+    info!("1. The account can only be controlled by the authorized addresses");
+    info!(
+        "2. You need {} signatures to execute any transaction",
+        threshold
+    );
+    info!("3. Make sure you have access to the authorized private keys!");
+    info!("4. This is a one-way conversion - test on testnet first!");
+
+    info!("Example completed - multi-sig conversion functionality demonstrated");
 }

--- a/src/bin/multi_sig_order.rs
+++ b/src/bin/multi_sig_order.rs
@@ -1,0 +1,94 @@
+use alloy::{primitives::Address, signers::local::PrivateKeySigner};
+use hyperliquid_rust_sdk::{BaseUrl, ClientLimit, ClientOrder, ClientOrderRequest, ExchangeClient};
+use log::info;
+use serde_json::json;
+
+fn setup_multi_sig_wallets() -> Vec<PrivateKeySigner> {
+    let wallets = vec![
+        "0x1234567890123456789012345678901234567890123456789012345678901234",
+        "0x2345678901234567890123456789012345678901234567890123456789012345",
+        "0x3456789012345678901234567890123456789012345678901234567890123456",
+    ];
+
+    wallets
+        .into_iter()
+        .map(|key| key.parse().unwrap())
+        .collect()
+}
+
+async fn setup_exchange_client() -> (Address, ExchangeClient) {
+    // Key was randomly generated for testing and shouldn't be used with any real funds
+    let wallet: PrivateKeySigner =
+        "e908f86dbb4d55ac876378565aafeabc187f6690f046459397b17d9b9a19688e"
+            .parse()
+            .unwrap();
+
+    let address = wallet.address();
+    let exchange_client = ExchangeClient::new(None, wallet, Some(BaseUrl::Testnet), None, None)
+        .await
+        .unwrap();
+
+    (address, exchange_client)
+}
+
+#[tokio::main]
+async fn main() {
+    env_logger::init();
+
+    let (address, exchange_client) = setup_exchange_client().await;
+
+    let multi_sig_user: Address = "0x0000000000000000000000000000000000000005"
+        .parse()
+        .unwrap();
+
+    let timestamp = chrono::Utc::now().timestamp_millis() as u64;
+
+    let action = json!({
+        "type": "order",
+        "orders": [{
+            "a": 0, // ETH asset index
+            "b": true,
+            "p": "1800",
+            "s": "0.01",
+            "r": false,
+            "t": {"limit": {"tif": "Gtc"}}
+        }],
+        "grouping": "na",
+    });
+
+    let typed_order = ClientOrderRequest {
+        asset: "ETH".to_string(),
+        is_buy: true,
+        reduce_only: false,
+        limit_px: 1800.0,
+        sz: 0.01,
+        cloid: None,
+        order_type: ClientOrder::Limit(ClientLimit {
+            tif: "Gtc".to_string(),
+        }),
+    };
+
+    info!("Multi-sig user: {}", multi_sig_user);
+    info!("Outer signer (current wallet): {}", address);
+    info!(
+        "Exchange client connected to: {:?}",
+        exchange_client.http_client.base_url
+    );
+    info!("Action: {}", action);
+    info!("Typed order: {:?}", typed_order);
+    info!("Timestamp: {}", timestamp);
+
+    let multi_sig_wallets = setup_multi_sig_wallets();
+    info!(
+        "Multi-sig wallets: {:?}",
+        multi_sig_wallets
+            .iter()
+            .map(|w| w.address())
+            .collect::<Vec<_>>()
+    );
+
+    info!("Multi-sig order functionality is not yet implemented in the Rust SDK");
+    info!("This example shows the structure and parameters that would be used:");
+
+    info!("Example completed successfully - multi-sig order parameters validated");
+}

--- a/src/bin/multi_sig_order.rs
+++ b/src/bin/multi_sig_order.rs
@@ -1,9 +1,10 @@
 use alloy::{primitives::Address, signers::local::PrivateKeySigner};
 use hyperliquid_rust_sdk::{BaseUrl, ClientLimit, ClientOrder, ClientOrderRequest, ExchangeClient};
 use log::info;
-use serde_json::json;
 
 fn setup_multi_sig_wallets() -> Vec<PrivateKeySigner> {
+    // These are example private keys - in production, these would be the authorized
+    // user wallets that have permission to sign for the multi-sig account
     let wallets = vec![
         "0x1234567890123456789012345678901234567890123456789012345678901234",
         "0x2345678901234567890123456789012345678901234567890123456789012345",
@@ -37,58 +38,85 @@ async fn main() {
 
     let (address, exchange_client) = setup_exchange_client().await;
 
+    // Set up the multi-sig wallets that are authorized to sign for the multi-sig user
+    // Each wallet must belong to a user that has been added as an authorized signer
+    let multi_sig_wallets = setup_multi_sig_wallets();
+
+    // The outer signer is required to be an authorized user or an agent of the
+    // authorized user of the multi-sig user.
+
+    // Address of the multi-sig user that the action will be executed for
+    // Executing the action requires at least the specified threshold of signatures
+    // required for that multi-sig user
     let multi_sig_user: Address = "0x0000000000000000000000000000000000000005"
         .parse()
         .unwrap();
 
-    let timestamp = chrono::Utc::now().timestamp_millis() as u64;
-
-    let action = json!({
-        "type": "order",
-        "orders": [{
-            "a": 0, // ETH asset index
-            "b": true,
-            "p": "1800",
-            "s": "0.01",
-            "r": false,
-            "t": {"limit": {"tif": "Gtc"}}
-        }],
-        "grouping": "na",
-    });
-
-    let typed_order = ClientOrderRequest {
-        asset: "ETH".to_string(),
-        is_buy: true,
-        reduce_only: false,
-        limit_px: 1800.0,
-        sz: 0.01,
-        cloid: None,
-        order_type: ClientOrder::Limit(ClientLimit {
-            tif: "Gtc".to_string(),
-        }),
-    };
-
-    info!("Multi-sig user: {}", multi_sig_user);
+    info!("=== Multi-Sig Order Example ===");
+    info!("Multi-sig user address: {}", multi_sig_user);
     info!("Outer signer (current wallet): {}", address);
     info!(
         "Exchange client connected to: {:?}",
         exchange_client.http_client.base_url
     );
-    info!("Action: {}", action);
-    info!("Typed order: {:?}", typed_order);
-    info!("Timestamp: {}", timestamp);
-
-    let multi_sig_wallets = setup_multi_sig_wallets();
     info!(
-        "Multi-sig wallets: {:?}",
+        "Authorized wallets ({} total): {:?}",
+        multi_sig_wallets.len(),
         multi_sig_wallets
             .iter()
             .map(|w| w.address())
             .collect::<Vec<_>>()
     );
 
-    info!("Multi-sig order functionality is not yet implemented in the Rust SDK");
-    info!("This example shows the structure and parameters that would be used:");
+    // Define the multi-sig inner action - in this case, placing an order
+    // This matches the Python example: asset index 4, buy, price 1100, size 0.2
+    let order = ClientOrderRequest {
+        asset: "ETH".to_string(), // Asset index 4 in Python corresponds to ETH
+        is_buy: true,
+        reduce_only: false,
+        limit_px: 1100.0,
+        sz: 0.2,
+        cloid: None,
+        order_type: ClientOrder::Limit(ClientLimit {
+            tif: "Gtc".to_string(),
+        }),
+    };
 
-    info!("Example completed successfully - multi-sig order parameters validated");
+    info!("");
+    info!("Order details: {:?}", order);
+    info!("Executing multi-sig order...");
+    info!(
+        "Collecting signatures from {} authorized wallets...",
+        multi_sig_wallets.len()
+    );
+
+    // Execute the multi-sig order
+    // This will collect signatures from all provided wallets and submit them together
+    // The action will only succeed if enough valid signatures are provided (>= threshold)
+    match exchange_client
+        .multi_sig_order(multi_sig_user, order, &multi_sig_wallets)
+        .await
+    {
+        Ok(response) => {
+            info!("✓ Multi-sig order placed successfully!");
+            info!("Response: {:?}", response);
+        }
+        Err(e) => {
+            info!("✗ Multi-sig order failed: {}", e);
+            info!("");
+            info!("This is expected if:");
+            info!("  • The multi-sig user is not properly configured");
+            info!("  • The provided wallets are not authorized signers");
+            info!("  • Not enough signatures provided to meet threshold");
+            info!("");
+            info!("To use in production:");
+            info!("  1. Convert a user to multi-sig: convert_to_multi_sig()");
+            info!("  2. Add authorized addresses: update_multi_sig_addresses()");
+            info!("  3. Use those authorized wallets to sign transactions");
+            info!("  4. Ensure you provide >= threshold number of valid signatures");
+        }
+    }
+
+    info!("");
+    info!("Example completed");
 }

--- a/src/bin/multi_sig_order_signature_collection.rs
+++ b/src/bin/multi_sig_order_signature_collection.rs
@@ -1,0 +1,151 @@
+/// Example: Multi-sig order placement with signature collection workflow
+///
+/// This demonstrates how to collect signatures for L1 actions (orders)
+/// where each signer creates their signature independently.
+///
+/// Usage:
+///   cargo run --bin multi_sig_order_signature_collection
+use alloy::signers::{local::PrivateKeySigner, Signature};
+use hyperliquid_rust_sdk::sign_multi_sig_l1_action_single;
+use log::info;
+use std::str::FromStr;
+
+type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+fn main() -> Result<()> {
+    env_logger::init();
+
+    info!("=== Multi-Sig Order Signature Collection Demo ===\n");
+
+    demonstrate_order_signature_collection()?;
+
+    Ok(())
+}
+
+fn demonstrate_order_signature_collection() -> Result<()> {
+    // Setup: Define the multi-sig parameters
+    let multi_sig_user =
+        alloy::primitives::Address::from_str("0x0000000000000000000000000000000000000005")?;
+    let outer_signer =
+        alloy::primitives::Address::from_str("0x0d1d9635d0640821d15e323ac8adadfa9c111414")?;
+    let nonce = 1234567890u64;
+
+    info!("Multi-sig parameters:");
+    info!("  Multi-sig user: {}", multi_sig_user);
+    info!("  Outer signer: {}", outer_signer);
+    info!("  Nonce: {}\n", nonce);
+
+    // Create the order action
+    // All signers must create the exact same action
+    let action = serde_json::json!({
+        "type": "order",
+        "orders": [{
+            "a": 0,          // asset index (0 = BTC)
+            "b": true,       // is_buy
+            "p": "30000",    // limit price
+            "s": "0.1",      // size
+            "r": false,      // reduce_only
+            "t": {"limit": {"tif": "Gtc"}}
+        }],
+        "grouping": "na"
+    });
+
+    info!("Order action:");
+    info!("{}\n", serde_json::to_string_pretty(&action)?);
+
+    // Step 1: Each signer creates their signature independently
+    info!("Step 1: Each signer creates their signature\n");
+
+    let signer1_wallet = "0xe908f86dbb4d55ac876378565aafeabc187f6690f046459397b17d9b9a19688e"
+        .parse::<PrivateKeySigner>()?;
+    let signer2_wallet = "0x0000000000000000000000000000000000000000000000000000000000000001"
+        .parse::<PrivateKeySigner>()?;
+
+    info!("Signer 1 address: {}", signer1_wallet.address());
+    info!("Signer 2 address: {}", signer2_wallet.address());
+
+    // Signer 1 signs the L1 action
+    let sig1 = sign_multi_sig_l1_action_single(
+        &signer1_wallet,
+        &action,
+        multi_sig_user,
+        outer_signer,
+        None, // vault_address
+        nonce,
+        None,  // expires_after
+        false, // is_mainnet = false (testnet)
+    )?;
+    info!("\nSigner 1 signature: {}", sig1);
+
+    // Signer 2 signs the L1 action
+    let sig2 = sign_multi_sig_l1_action_single(
+        &signer2_wallet,
+        &action,
+        multi_sig_user,
+        outer_signer,
+        None,
+        nonce,
+        None,
+        false,
+    )?;
+    info!("Signer 2 signature: {}", sig2);
+
+    // Step 2: Signatures are serialized and transmitted
+    info!("\nStep 2: Signatures are exported for transmission\n");
+
+    let sig1_string = sig1.to_string();
+    let sig2_string = sig2.to_string();
+
+    info!("Sig 1 exported: {}", sig1_string);
+    info!("Sig 2 exported: {}", sig2_string);
+
+    // Step 3: Submitter collects and imports signatures
+    info!("\nStep 3: Submitter collects signatures\n");
+
+    let collected_signatures = [sig1_string, sig2_string];
+    info!("Collected {} signatures", collected_signatures.len());
+
+    // Import signatures
+    let signatures: Vec<Signature> = collected_signatures
+        .iter()
+        .map(|s| s.parse().expect("Failed to import signature"))
+        .collect();
+
+    info!("Successfully imported {} signatures", signatures.len());
+
+    // Step 4: Show how to submit (commented out to avoid actual submission)
+    info!("\nStep 4: Submit order (example - not executed)\n");
+
+    info!("To submit, the outer signer would run:");
+    info!("```rust");
+    info!("let submitter_wallet = \"YOUR_KEY\".parse::<PrivateKeySigner>()?;");
+    info!("let sdk = ExchangeClient::new(submitter_wallet, Some(BaseUrl::Testnet), None).await?;");
+    info!("");
+    info!("let order = ClientOrderRequest {{");
+    info!("    asset: \"BTC\".to_string(),");
+    info!("    is_buy: true,");
+    info!("    reduce_only: false,");
+    info!("    limit_px: 30000.0,");
+    info!("    sz: 0.1,");
+    info!("    order_type: ClientOrderType::Limit(ClientLimit {{");
+    info!("        tif: \"Gtc\".to_string(),");
+    info!("    }}),");
+    info!("    cloid: None,");
+    info!("}};");
+    info!("");
+    info!("sdk.multi_sig_order_with_signatures(");
+    info!("    multi_sig_user,");
+    info!("    order,");
+    info!("    signatures,");
+    info!(").await?;");
+    info!("```");
+
+    info!("\n=== Demo Complete ===");
+    info!("\nKey differences for L1 actions (orders):");
+    info!("1. Use sign_multi_sig_l1_action_single instead of sign_multi_sig_user_signed_action_single");
+    info!("2. Sign the JSON action directly (type + orders/cancels/etc)");
+    info!("3. Must specify vault_address and expires_after parameters");
+    info!("4. Network parameter (is_mainnet) affects the signature");
+
+    Ok(())
+}

--- a/src/bin/multi_sig_order_signature_collection.rs
+++ b/src/bin/multi_sig_order_signature_collection.rs
@@ -37,7 +37,7 @@ fn demonstrate_order_signature_collection() -> Result<()> {
 
     // Create the order action
     // All signers must create the exact same action
-    let action = serde_json::json!({
+    let action = serde_json::from_value(serde_json::json!({
         "type": "order",
         "orders": [{
             "a": 0,          // asset index (0 = BTC)
@@ -48,7 +48,8 @@ fn demonstrate_order_signature_collection() -> Result<()> {
             "t": {"limit": {"tif": "Gtc"}}
         }],
         "grouping": "na"
-    });
+    }))
+    .unwrap();
 
     info!("Order action:");
     info!("{}\n", serde_json::to_string_pretty(&action)?);

--- a/src/bin/multi_sig_register_token.rs
+++ b/src/bin/multi_sig_register_token.rs
@@ -1,7 +1,6 @@
 use alloy::{primitives::Address, signers::local::PrivateKeySigner};
 use hyperliquid_rust_sdk::{BaseUrl, ExchangeClient};
 use log::info;
-use serde_json::json;
 
 fn setup_multi_sig_wallets() -> Vec<PrivateKeySigner> {
     let wallets = vec![
@@ -27,34 +26,23 @@ async fn setup_exchange_client() -> (Address, ExchangeClient) {
     let exchange_client = ExchangeClient::new(None, wallet, Some(BaseUrl::Testnet), None, None)
         .await
         .unwrap();
-    
+
     (address, exchange_client)
 }
 
 #[tokio::main]
 async fn main() {
     env_logger::init();
-    
+
     let (address, exchange_client) = setup_exchange_client().await;
 
+    // The multi-sig user address (this would be the address that was converted to multi-sig)
     let multi_sig_user: Address = "0x0000000000000000000000000000000000000005"
         .parse()
         .unwrap();
 
-    let timestamp = chrono::Utc::now().timestamp_millis() as u64;
-
-    let action = json!({
-        "type": "spotDeploy",
-        "registerToken2": {
-            "spec": {
-                "name": "TESTH",
-                "szDecimals": 2,
-                "weiDecimals": 8
-            },
-            "maxGas": 1000000000000u64,
-            "fullName": "Example multi-sig spot deploy"
-        }
-    });
+    // Set up the multi-sig wallets that are authorized to sign for the multi-sig user
+    let multi_sig_wallets = setup_multi_sig_wallets();
 
     info!("Multi-sig user: {}", multi_sig_user);
     info!("Outer signer (current wallet): {}", address);
@@ -62,10 +50,6 @@ async fn main() {
         "Exchange client connected to: {:?}",
         exchange_client.http_client.base_url
     );
-    info!("Action: {}", action);
-    info!("Timestamp: {}", timestamp);
-
-    let multi_sig_wallets = setup_multi_sig_wallets();
     info!(
         "Multi-sig wallets: {:?}",
         multi_sig_wallets
@@ -74,8 +58,19 @@ async fn main() {
             .collect::<Vec<_>>()
     );
 
-    info!("Multi-sig register token functionality is not yet implemented in the Rust SDK");
-    info!("This example shows the structure and parameters that would be used:");
+    info!("Multi-sig register token functionality requires custom action handling");
+    info!("The spot token registration action (spotDeploy) is a complex action that:");
+    info!("1. Requires specific permission levels");
+    info!("2. Has custom parameters for token specification");
+    info!("3. Is typically used for specialized spot market operations");
+    info!("");
+    info!("For multi-sig spot token registration, you would:");
+    info!("1. Create a custom spotDeploy action with registerToken2 parameters");
+    info!("2. Hash the action using the Actions::hash method");
+    info!("3. Sign with multiple authorized wallets using sign_l1_action_multi_sig");
+    info!("4. Submit using the post_multi_sig method");
+    info!("");
+    info!("This is an advanced operation - consult Hyperliquid documentation for details");
 
-    info!("Example completed successfully - multi-sig register token parameters validated");
+    info!("Example completed - multi-sig register token requirements explained");
 }

--- a/src/bin/multi_sig_register_token.rs
+++ b/src/bin/multi_sig_register_token.rs
@@ -1,0 +1,81 @@
+use alloy::{primitives::Address, signers::local::PrivateKeySigner};
+use hyperliquid_rust_sdk::{BaseUrl, ExchangeClient};
+use log::info;
+use serde_json::json;
+
+fn setup_multi_sig_wallets() -> Vec<PrivateKeySigner> {
+    let wallets = vec![
+        "0x1234567890123456789012345678901234567890123456789012345678901234",
+        "0x2345678901234567890123456789012345678901234567890123456789012345",
+        "0x3456789012345678901234567890123456789012345678901234567890123456",
+    ];
+
+    wallets
+        .into_iter()
+        .map(|key| key.parse().unwrap())
+        .collect()
+}
+
+async fn setup_exchange_client() -> (Address, ExchangeClient) {
+    // Key was randomly generated for testing and shouldn't be used with any real funds
+    let wallet: PrivateKeySigner =
+        "e908f86dbb4d55ac876378565aafeabc187f6690f046459397b17d9b9a19688e"
+            .parse()
+            .unwrap();
+
+    let address = wallet.address();
+    let exchange_client = ExchangeClient::new(None, wallet, Some(BaseUrl::Testnet), None, None)
+        .await
+        .unwrap();
+    
+    (address, exchange_client)
+}
+
+#[tokio::main]
+async fn main() {
+    env_logger::init();
+    
+    let (address, exchange_client) = setup_exchange_client().await;
+
+    let multi_sig_user: Address = "0x0000000000000000000000000000000000000005"
+        .parse()
+        .unwrap();
+
+    let timestamp = chrono::Utc::now().timestamp_millis() as u64;
+
+    let action = json!({
+        "type": "spotDeploy",
+        "registerToken2": {
+            "spec": {
+                "name": "TESTH",
+                "szDecimals": 2,
+                "weiDecimals": 8
+            },
+            "maxGas": 1000000000000u64,
+            "fullName": "Example multi-sig spot deploy"
+        }
+    });
+
+    info!("Multi-sig user: {}", multi_sig_user);
+    info!("Outer signer (current wallet): {}", address);
+    info!(
+        "Exchange client connected to: {:?}",
+        exchange_client.http_client.base_url
+    );
+    info!("Action: {}", action);
+    info!("Timestamp: {}", timestamp);
+
+    let multi_sig_wallets = setup_multi_sig_wallets();
+    info!(
+        "Multi-sig wallets: {:?}",
+        multi_sig_wallets
+            .iter()
+            .map(|w| w.address())
+            .collect::<Vec<_>>()
+    );
+
+    info!("Multi-sig register token functionality is not yet implemented in the Rust SDK");
+    info!("This example shows the structure and parameters that would be used:");
+
+    info!("Example completed successfully - multi-sig register token parameters validated");
+}

--- a/src/bin/multi_sig_signature_collection.rs
+++ b/src/bin/multi_sig_signature_collection.rs
@@ -7,7 +7,9 @@
 /// Usage:
 ///   cargo run --bin multi_sig_signature_collection
 use alloy::signers::{local::PrivateKeySigner, Signature};
-use hyperliquid_rust_sdk::{sign_multi_sig_user_signed_action_single, SendAsset};
+use hyperliquid_rust_sdk::{
+    sign_multi_sig_user_signed_action_single, MultiSigExtension, SendAsset,
+};
 use log::info;
 use std::str::FromStr;
 
@@ -132,8 +134,10 @@ fn create_send_asset(
         amount: amount.to_string(),
         from_sub_account: "".to_string(),
         nonce,
-        payload_multi_sig_user: Some(format!("{:#x}", multi_sig_user).to_lowercase()),
-        outer_signer: Some(format!("{:#x}", outer_signer).to_lowercase()),
+        multi_sig_ext: Some(MultiSigExtension {
+            payload_multi_sig_user: format!("{:#x}", multi_sig_user).to_lowercase(),
+            outer_signer: format!("{:#x}", outer_signer).to_lowercase(),
+        }),
     }
 }
 

--- a/src/bin/multi_sig_signature_collection.rs
+++ b/src/bin/multi_sig_signature_collection.rs
@@ -54,7 +54,7 @@ fn demonstrate_signature_collection() -> Result<()> {
     info!("Signer 2 address: {}", signer2_wallet.address());
 
     // Both signers create the same SendAsset action
-    let send_asset = create_send_asset(destination, amount, nonce);
+    let send_asset = create_send_asset(multi_sig_user, outer_signer, destination, amount, nonce);
 
     // Signer 1 signs
     let sig1 = sign_multi_sig_user_signed_action_single(&signer1_wallet, &send_asset)?;
@@ -115,7 +115,13 @@ fn demonstrate_signature_collection() -> Result<()> {
 }
 
 /// Create a SendAsset action - must be identical for all signers
-fn create_send_asset(destination: &str, amount: &str, nonce: u64) -> SendAsset {
+fn create_send_asset(
+    multi_sig_user: alloy::primitives::Address,
+    outer_signer: alloy::primitives::Address,
+    destination: &str,
+    amount: &str,
+    nonce: u64,
+) -> SendAsset {
     SendAsset {
         signature_chain_id: 421614,
         hyperliquid_chain: "Testnet".to_string(),
@@ -126,6 +132,8 @@ fn create_send_asset(destination: &str, amount: &str, nonce: u64) -> SendAsset {
         amount: amount.to_string(),
         from_sub_account: "".to_string(),
         nonce,
+        payload_multi_sig_user: Some(format!("{:#x}", multi_sig_user).to_lowercase()),
+        outer_signer: Some(format!("{:#x}", outer_signer).to_lowercase()),
     }
 }
 

--- a/src/bin/multi_sig_signature_collection.rs
+++ b/src/bin/multi_sig_signature_collection.rs
@@ -54,7 +54,7 @@ fn demonstrate_signature_collection() -> Result<()> {
     info!("Signer 2 address: {}", signer2_wallet.address());
 
     // Both signers create the same SendAsset action
-    let send_asset = create_send_asset(multi_sig_user, outer_signer, destination, amount, nonce);
+    let send_asset = create_send_asset(destination, amount, nonce);
 
     // Signer 1 signs
     let sig1 = sign_multi_sig_user_signed_action_single(&signer1_wallet, &send_asset)?;
@@ -115,13 +115,7 @@ fn demonstrate_signature_collection() -> Result<()> {
 }
 
 /// Create a SendAsset action - must be identical for all signers
-fn create_send_asset(
-    multi_sig_user: alloy::primitives::Address,
-    outer_signer: alloy::primitives::Address,
-    destination: &str,
-    amount: &str,
-    nonce: u64,
-) -> SendAsset {
+fn create_send_asset(destination: &str, amount: &str, nonce: u64) -> SendAsset {
     SendAsset {
         signature_chain_id: 421614,
         hyperliquid_chain: "Testnet".to_string(),
@@ -132,8 +126,6 @@ fn create_send_asset(
         amount: amount.to_string(),
         from_sub_account: "".to_string(),
         nonce,
-        payload_multi_sig_user: Some(format!("{:#x}", multi_sig_user).to_lowercase()),
-        outer_signer: Some(format!("{:#x}", outer_signer).to_lowercase()),
     }
 }
 

--- a/src/bin/multi_sig_signature_collection.rs
+++ b/src/bin/multi_sig_signature_collection.rs
@@ -1,0 +1,150 @@
+/// Example: Multi-sig USDC transfer with signature collection workflow
+///
+/// This demonstrates the recommended approach where signatures are collected
+/// from different parties independently, rather than having all private keys
+/// in one place.
+///
+/// Usage:
+///   cargo run --bin multi_sig_signature_collection
+use alloy::signers::{local::PrivateKeySigner, Signature};
+use hyperliquid_rust_sdk::{sign_multi_sig_user_signed_action_single, SendAsset};
+use log::info;
+use std::str::FromStr;
+
+type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+fn main() -> Result<()> {
+    env_logger::init();
+
+    info!("=== Multi-Sig Signature Collection Demo ===\n");
+
+    // Simulate the workflow
+    demonstrate_signature_collection()?;
+
+    Ok(())
+}
+
+fn demonstrate_signature_collection() -> Result<()> {
+    // Setup: Define the multi-sig parameters
+    // In a real scenario, these would be coordinated among all parties
+    let multi_sig_user =
+        alloy::primitives::Address::from_str("0x0000000000000000000000000000000000000005")?;
+    let outer_signer =
+        alloy::primitives::Address::from_str("0x0d1d9635d0640821d15e323ac8adadfa9c111414")?;
+    let destination = "0x1234567890123456789012345678901234567890";
+    let amount = "100";
+    let nonce = 1234567890u64;
+
+    info!("Multi-sig parameters:");
+    info!("  Multi-sig user: {}", multi_sig_user);
+    info!("  Outer signer: {}", outer_signer);
+    info!("  Destination: {}", destination);
+    info!("  Amount: {}", amount);
+    info!("  Nonce: {}\n", nonce);
+
+    // Step 1: Each signer creates their signature independently
+    info!("Step 1: Each signer creates their signature\n");
+
+    let signer1_wallet = "0xe908f86dbb4d55ac876378565aafeabc187f6690f046459397b17d9b9a19688e"
+        .parse::<PrivateKeySigner>()?;
+    let signer2_wallet = "0x0000000000000000000000000000000000000000000000000000000000000001"
+        .parse::<PrivateKeySigner>()?;
+
+    info!("Signer 1 address: {}", signer1_wallet.address());
+    info!("Signer 2 address: {}", signer2_wallet.address());
+
+    // Both signers create the same SendAsset action
+    let send_asset = create_send_asset(multi_sig_user, outer_signer, destination, amount, nonce);
+
+    // Signer 1 signs
+    let sig1 = sign_multi_sig_user_signed_action_single(&signer1_wallet, &send_asset)?;
+    info!("\nSigner 1 signature: {}", sig1);
+
+    // Signer 2 signs
+    let sig2 = sign_multi_sig_user_signed_action_single(&signer2_wallet, &send_asset)?;
+    info!("Signer 2 signature: {}", sig2);
+
+    // Step 2: Signatures are serialized and transmitted
+    info!("\nStep 2: Signatures are exported for transmission\n");
+
+    let sig1_string = export_signature(&sig1);
+    let sig2_string = export_signature(&sig2);
+
+    info!("Sig 1 exported: {}", sig1_string);
+    info!("Sig 2 exported: {}", sig2_string);
+
+    // Step 3: Submitter collects and imports signatures
+    info!("\nStep 3: Submitter collects signatures\n");
+
+    let collected_signatures = [sig1_string, sig2_string];
+    info!("Collected {} signatures", collected_signatures.len());
+
+    // Import signatures
+    let signatures: Vec<Signature> = collected_signatures
+        .iter()
+        .map(|s| import_signature(s).expect("Failed to import signature"))
+        .collect();
+
+    info!("Successfully imported {} signatures", signatures.len());
+
+    // Step 4: Show how to submit (commented out to avoid actual submission)
+    info!("\nStep 4: Submit transaction (example - not executed)\n");
+
+    info!("To submit, the outer signer would run:");
+    info!("```rust");
+    info!("let submitter_wallet = \"YOUR_KEY\".parse::<PrivateKeySigner>()?;");
+    info!("let sdk = ExchangeClient::new(submitter_wallet, Some(BaseUrl::Testnet), None).await?;");
+    info!("");
+    info!("sdk.multi_sig_usdc_transfer_with_signatures(");
+    info!("    multi_sig_user,");
+    info!("    \"{}\",", amount);
+    info!("    \"{}\",", destination);
+    info!("    signatures,");
+    info!(").await?;");
+    info!("```");
+
+    info!("\n=== Demo Complete ===");
+    info!("\nKey takeaways:");
+    info!("1. Each signer creates their signature independently");
+    info!("2. Signatures can be serialized as hex strings for transmission");
+    info!("3. The submitter collects and combines signatures");
+    info!("4. All signers must sign identical action parameters");
+    info!("5. The outer_signer (submitter) doesn't need to be a multi-sig participant");
+
+    Ok(())
+}
+
+/// Create a SendAsset action - must be identical for all signers
+fn create_send_asset(
+    multi_sig_user: alloy::primitives::Address,
+    outer_signer: alloy::primitives::Address,
+    destination: &str,
+    amount: &str,
+    nonce: u64,
+) -> SendAsset {
+    SendAsset {
+        signature_chain_id: 421614,
+        hyperliquid_chain: "Testnet".to_string(),
+        destination: destination.to_string(),
+        source_dex: "".to_string(),
+        destination_dex: "".to_string(),
+        token: "USDC".to_string(),
+        amount: amount.to_string(),
+        from_sub_account: "".to_string(),
+        nonce,
+        payload_multi_sig_user: Some(format!("{:#x}", multi_sig_user).to_lowercase()),
+        outer_signer: Some(format!("{:#x}", outer_signer).to_lowercase()),
+    }
+}
+
+/// Export a signature as a hex string
+fn export_signature(sig: &Signature) -> String {
+    sig.to_string()
+}
+
+/// Import a signature from a hex string
+fn import_signature(sig_str: &str) -> Result<Signature> {
+    sig_str
+        .parse()
+        .map_err(|e| format!("Failed to parse signature: {:?}", e).into())
+}

--- a/src/bin/multi_sig_signature_collection.rs
+++ b/src/bin/multi_sig_signature_collection.rs
@@ -127,7 +127,7 @@ fn create_send_asset(
     SendAsset {
         signature_chain_id: 421614,
         hyperliquid_chain: "Testnet".to_string(),
-        destination: destination.to_string(),
+        destination: destination.to_lowercase(),
         source_dex: "".to_string(),
         destination_dex: "".to_string(),
         token: "USDC".to_string(),

--- a/src/bin/multi_sig_usd_send.rs
+++ b/src/bin/multi_sig_usd_send.rs
@@ -1,0 +1,77 @@
+use alloy::{primitives::Address, signers::local::PrivateKeySigner};
+use hyperliquid_rust_sdk::{BaseUrl, ExchangeClient};
+use log::info;
+use serde_json::json;
+
+fn setup_multi_sig_wallets() -> Vec<PrivateKeySigner> {
+    let wallets = vec![
+        "0x1234567890123456789012345678901234567890123456789012345678901234",
+        "0x2345678901234567890123456789012345678901234567890123456789012345",
+        "0x3456789012345678901234567890123456789012345678901234567890123456",
+    ];
+
+    wallets
+        .into_iter()
+        .map(|key| key.parse().unwrap())
+        .collect()
+}
+
+async fn setup_exchange_client() -> (Address, ExchangeClient) {
+    // Key was randomly generated for testing and shouldn't be used with any real funds
+    let wallet: PrivateKeySigner =
+        "e908f86dbb4d55ac876378565aafeabc187f6690f046459397b17d9b9a19688e"
+            .parse()
+            .unwrap();
+
+    let address = wallet.address();
+    let exchange_client = ExchangeClient::new(None, wallet, Some(BaseUrl::Testnet), None, None)
+        .await
+        .unwrap();
+    
+    (address, exchange_client)
+}
+
+#[tokio::main]
+async fn main() {
+    env_logger::init();
+    
+    let (address, exchange_client) = setup_exchange_client().await;
+
+    let multi_sig_user: Address = "0x0000000000000000000000000000000000000005"
+        .parse()
+        .unwrap();
+
+    let timestamp = chrono::Utc::now().timestamp_millis() as u64;
+
+    let action = json!({
+        "type": "usdSend",
+        "signatureChainId": "0x66eee",
+        "hyperliquidChain": "Testnet",
+        "destination": "0x0D1d9635D0640821d15e323ac8AdADfA9c111414",
+        "amount": "1.0",
+        "time": timestamp
+    });
+
+    info!("Multi-sig user: {}", multi_sig_user);
+    info!("Outer signer (current wallet): {}", address);
+    info!(
+        "Exchange client connected to: {:?}",
+        exchange_client.http_client.base_url
+    );
+    info!("Action: {}", action);
+    info!("Timestamp: {}", timestamp);
+
+    let multi_sig_wallets = setup_multi_sig_wallets();
+    info!(
+        "Multi-sig wallets: {:?}",
+        multi_sig_wallets
+            .iter()
+            .map(|w| w.address())
+            .collect::<Vec<_>>()
+    );
+
+    info!("Multi-sig USD send functionality is not yet implemented in the Rust SDK");
+    info!("This example shows the structure and parameters that would be used:");
+
+    info!("Example completed successfully - multi-sig USD send parameters validated");
+}

--- a/src/exchange/actions.rs
+++ b/src/exchange/actions.rs
@@ -210,10 +210,6 @@ pub struct SendAsset {
     pub amount: String,
     pub from_sub_account: String,
     pub nonce: u64,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub payload_multi_sig_user: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub outer_signer: Option<String>,
 }
 
 impl Eip712 for SendAsset {
@@ -222,31 +218,7 @@ impl Eip712 for SendAsset {
     }
 
     fn struct_hash(&self) -> B256 {
-        if self.payload_multi_sig_user.is_some() && self.outer_signer.is_some() {
-            let multi_sig_user: Address = self
-                .payload_multi_sig_user
-                .as_ref()
-                .unwrap()
-                .parse()
-                .unwrap();
-            let outer_signer: Address = self.outer_signer.as_ref().unwrap().parse().unwrap();
-
-            let items = (
-                keccak256("HyperliquidTransaction:SendAsset(string hyperliquidChain,address payloadMultiSigUser,address outerSigner,string destination,string sourceDex,string destinationDex,string token,string amount,string fromSubAccount,uint64 nonce)"),
-                keccak256(&self.hyperliquid_chain),
-                multi_sig_user,
-                outer_signer,
-                keccak256(&self.destination),
-                keccak256(&self.source_dex),
-                keccak256(&self.destination_dex),
-                keccak256(&self.token),
-                keccak256(&self.amount),
-                keccak256(&self.from_sub_account),
-                &self.nonce,
-            );
-            keccak256(items.abi_encode())
-        } else {
-            let items = (
+        let items = (
                 keccak256("HyperliquidTransaction:SendAsset(string hyperliquidChain,string destination,string sourceDex,string destinationDex,string token,string amount,string fromSubAccount,uint64 nonce)"),
                 keccak256(&self.hyperliquid_chain),
                 keccak256(&self.destination),
@@ -257,8 +229,7 @@ impl Eip712 for SendAsset {
                 keccak256(&self.from_sub_account),
                 &self.nonce,
             );
-            keccak256(items.abi_encode())
-        }
+        keccak256(items.abi_encode())
     }
 }
 

--- a/src/exchange/actions.rs
+++ b/src/exchange/actions.rs
@@ -223,9 +223,14 @@ impl Eip712 for SendAsset {
 
     fn struct_hash(&self) -> B256 {
         if self.payload_multi_sig_user.is_some() && self.outer_signer.is_some() {
-            let multi_sig_user: Address = self.payload_multi_sig_user.as_ref().unwrap().parse().unwrap();
+            let multi_sig_user: Address = self
+                .payload_multi_sig_user
+                .as_ref()
+                .unwrap()
+                .parse()
+                .unwrap();
             let outer_signer: Address = self.outer_signer.as_ref().unwrap().parse().unwrap();
-            
+
             let items = (
                 keccak256("HyperliquidTransaction:SendAsset(string hyperliquidChain,address payloadMultiSigUser,address outerSigner,string destination,string sourceDex,string destinationDex,string token,string amount,string fromSubAccount,uint64 nonce)"),
                 keccak256(&self.hyperliquid_chain),

--- a/src/exchange/actions.rs
+++ b/src/exchange/actions.rs
@@ -210,6 +210,10 @@ pub struct SendAsset {
     pub amount: String,
     pub from_sub_account: String,
     pub nonce: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub payload_multi_sig_user: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub outer_signer: Option<String>,
 }
 
 impl Eip712 for SendAsset {
@@ -218,7 +222,31 @@ impl Eip712 for SendAsset {
     }
 
     fn struct_hash(&self) -> B256 {
-        let items = (
+        if self.payload_multi_sig_user.is_some() && self.outer_signer.is_some() {
+            let multi_sig_user: Address = self
+                .payload_multi_sig_user
+                .as_ref()
+                .unwrap()
+                .parse()
+                .unwrap();
+            let outer_signer: Address = self.outer_signer.as_ref().unwrap().parse().unwrap();
+
+            let items = (
+                keccak256("HyperliquidTransaction:SendAsset(string hyperliquidChain,address payloadMultiSigUser,address outerSigner,string destination,string sourceDex,string destinationDex,string token,string amount,string fromSubAccount,uint64 nonce)"),
+                keccak256(&self.hyperliquid_chain),
+                multi_sig_user,
+                outer_signer,
+                keccak256(&self.destination),
+                keccak256(&self.source_dex),
+                keccak256(&self.destination_dex),
+                keccak256(&self.token),
+                keccak256(&self.amount),
+                keccak256(&self.from_sub_account),
+                &self.nonce,
+            );
+            keccak256(items.abi_encode())
+        } else {
+            let items = (
                 keccak256("HyperliquidTransaction:SendAsset(string hyperliquidChain,string destination,string sourceDex,string destinationDex,string token,string amount,string fromSubAccount,uint64 nonce)"),
                 keccak256(&self.hyperliquid_chain),
                 keccak256(&self.destination),
@@ -229,7 +257,8 @@ impl Eip712 for SendAsset {
                 keccak256(&self.from_sub_account),
                 &self.nonce,
             );
-        keccak256(items.abi_encode())
+            keccak256(items.abi_encode())
+        }
     }
 }
 

--- a/src/exchange/exchange_client.rs
+++ b/src/exchange/exchange_client.rs
@@ -300,7 +300,7 @@ impl ExchangeClient {
         let usd_send = UsdSend {
             signature_chain_id: 421614,
             hyperliquid_chain,
-            destination: destination.to_string(),
+            destination: destination.to_lowercase(),
             amount: amount.to_string(),
             time: timestamp,
         };
@@ -361,7 +361,7 @@ impl ExchangeClient {
         let send_asset = SendAsset {
             signature_chain_id: 421614,
             hyperliquid_chain,
-            destination: destination.to_string(),
+            destination: destination.to_lowercase(),
             source_dex: source_dex.to_string(),
             destination_dex: destination_dex.to_string(),
             token: token.to_string(),
@@ -843,7 +843,7 @@ impl ExchangeClient {
         let withdraw = Withdraw3 {
             signature_chain_id: 421614,
             hyperliquid_chain,
-            destination: destination.to_string(),
+            destination: destination.to_lowercase(),
             amount: amount.to_string(),
             time: timestamp,
         };
@@ -872,7 +872,7 @@ impl ExchangeClient {
         let spot_send = SpotSend {
             signature_chain_id: 421614,
             hyperliquid_chain,
-            destination: destination.to_string(),
+            destination: destination.to_lowercase(),
             amount: amount.to_string(),
             time: timestamp,
             token: token.to_string(),
@@ -1198,7 +1198,7 @@ impl ExchangeClient {
         let send_asset = SendAsset {
             signature_chain_id: 421614,
             hyperliquid_chain,
-            destination: destination.to_string(),
+            destination: destination.to_lowercase(),
             source_dex: "".to_string(),
             destination_dex: "".to_string(),
             token: "USDC".to_string(),
@@ -1243,7 +1243,7 @@ impl ExchangeClient {
         let send_asset = SendAsset {
             signature_chain_id: 421614,
             hyperliquid_chain,
-            destination: destination.to_string(),
+            destination: destination.to_lowercase(),
             source_dex: "".to_string(),
             destination_dex: "".to_string(),
             token: token.to_string(),
@@ -1338,7 +1338,7 @@ impl ExchangeClient {
         let send_asset = SendAsset {
             signature_chain_id: 421614,
             hyperliquid_chain,
-            destination: destination.to_string(),
+            destination: destination.to_lowercase(),
             source_dex: "".to_string(),
             destination_dex: "".to_string(),
             token: "USDC".to_string(),
@@ -1391,7 +1391,7 @@ impl ExchangeClient {
         let send_asset = SendAsset {
             signature_chain_id: 421614,
             hyperliquid_chain,
-            destination: destination.to_string(),
+            destination: destination.to_lowercase(),
             source_dex: "".to_string(),
             destination_dex: "".to_string(),
             token: token.to_string(),

--- a/src/exchange/exchange_client.rs
+++ b/src/exchange/exchange_client.rs
@@ -23,6 +23,7 @@ use crate::{
     SpotSend, SpotUser, VaultTransfer, Withdraw3,
 };
 use alloy::{
+    hex,
     primitives::{keccak256, Address, Signature, B256},
     signers::local::PrivateKeySigner,
 };
@@ -93,8 +94,8 @@ where
     let mut seq = s.serialize_seq(Some(sigs.len()))?;
     for sig in sigs {
         let sig_obj = SignatureObj {
-            r: sig.r(),
-            s: sig.s(),
+            r: format!("0x{}", hex::encode::<[u8; 32]>(sig.r().to_be_bytes())),
+            s: format!("0x{}", hex::encode::<[u8; 32]>(sig.s().to_be_bytes())),
             v: 27 + sig.v() as u64,
         };
         seq.serialize_element(&sig_obj)?;
@@ -104,8 +105,8 @@ where
 
 #[derive(Serialize)]
 struct SignatureObj {
-    r: alloy::primitives::U256,
-    s: alloy::primitives::U256,
+    r: String,
+    s: String,
     v: u64,
 }
 

--- a/src/exchange/exchange_client.rs
+++ b/src/exchange/exchange_client.rs
@@ -1194,7 +1194,7 @@ impl ExchangeClient {
             "Testnet".to_string()
         };
 
-        let timestamp = 1111111;
+        let timestamp = next_nonce();
 
         let send_asset = SendAsset {
             signature_chain_id: 421614,

--- a/src/exchange/exchange_client.rs
+++ b/src/exchange/exchange_client.rs
@@ -1194,7 +1194,7 @@ impl ExchangeClient {
             "Testnet".to_string()
         };
 
-        let timestamp = next_nonce();
+        let timestamp = 1111111;
 
         let send_asset = SendAsset {
             signature_chain_id: 421614,

--- a/src/exchange/exchange_client.rs
+++ b/src/exchange/exchange_client.rs
@@ -368,6 +368,8 @@ impl ExchangeClient {
             amount: amount.to_string(),
             from_sub_account,
             nonce: timestamp,
+            payload_multi_sig_user: None,
+            outer_signer: None,
         };
 
         let signature = sign_typed_data(&send_asset, wallet)?;
@@ -1204,6 +1206,8 @@ impl ExchangeClient {
             amount: amount.to_string(),
             from_sub_account: "".to_string(),
             nonce: timestamp,
+            payload_multi_sig_user: Some(format!("{:#x}", multi_sig_user).to_lowercase()),
+            outer_signer: Some(format!("{:#x}", self.wallet.address()).to_lowercase()),
         };
 
         let signatures = sign_typed_data_multi_sig(&send_asset, wallets)?;
@@ -1245,6 +1249,8 @@ impl ExchangeClient {
             amount: amount.to_string(),
             from_sub_account: "".to_string(),
             nonce: timestamp,
+            payload_multi_sig_user: Some(format!("{:#x}", multi_sig_user).to_lowercase()),
+            outer_signer: Some(format!("{:#x}", self.wallet.address()).to_lowercase()),
         };
 
         let signatures = sign_typed_data_multi_sig(&send_asset, wallets)?;
@@ -1293,6 +1299,8 @@ impl ExchangeClient {
     ///     amount: "100".to_string(),
     ///     from_sub_account: "".to_string(),
     ///     nonce: 123456789,
+    ///     payload_multi_sig_user: Some(format!("{:#x}", multi_sig_user).to_lowercase()),
+    ///     outer_signer: Some("0x...".to_lowercase()),
     /// };
     ///
     /// let sig1 = sign_multi_sig_user_signed_action_single(&wallet1, &send_asset)?;
@@ -1332,6 +1340,8 @@ impl ExchangeClient {
             amount: amount.to_string(),
             from_sub_account: "".to_string(),
             nonce: timestamp,
+            payload_multi_sig_user: Some(format!("{:#x}", multi_sig_user).to_lowercase()),
+            outer_signer: Some(format!("{:#x}", self.wallet.address()).to_lowercase()),
         };
 
         let mut action =
@@ -1381,6 +1391,8 @@ impl ExchangeClient {
             amount: amount.to_string(),
             from_sub_account: "".to_string(),
             nonce: timestamp,
+            payload_multi_sig_user: Some(format!("{:#x}", multi_sig_user).to_lowercase()),
+            outer_signer: Some(format!("{:#x}", self.wallet.address()).to_lowercase()),
         };
 
         let mut action =
@@ -1647,6 +1659,8 @@ mod tests {
             amount: "100".to_string(),
             from_sub_account: "".to_string(),
             nonce: 1583838,
+            payload_multi_sig_user: None,
+            outer_signer: None,
         };
 
         let mainnet_signature = sign_typed_data(&mainnet_send, &wallet)?;
@@ -1661,6 +1675,8 @@ mod tests {
             amount: "50".to_string(),
             from_sub_account: "".to_string(),
             nonce: 1583838,
+            payload_multi_sig_user: None,
+            outer_signer: None,
         };
 
         let testnet_signature = sign_typed_data(&testnet_send, &wallet)?;
@@ -1676,6 +1692,8 @@ mod tests {
             amount: "100".to_string(),
             from_sub_account: "0xabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd".to_string(),
             nonce: 1583838,
+            payload_multi_sig_user: None,
+            outer_signer: None,
         };
 
         let vault_signature = sign_typed_data(&vault_send, &wallet)?;

--- a/src/exchange/exchange_client.rs
+++ b/src/exchange/exchange_client.rs
@@ -368,8 +368,6 @@ impl ExchangeClient {
             amount: amount.to_string(),
             from_sub_account,
             nonce: timestamp,
-            payload_multi_sig_user: None,
-            outer_signer: None,
         };
 
         let signature = sign_typed_data(&send_asset, wallet)?;
@@ -1206,8 +1204,6 @@ impl ExchangeClient {
             amount: amount.to_string(),
             from_sub_account: "".to_string(),
             nonce: timestamp,
-            payload_multi_sig_user: Some(format!("{:#x}", multi_sig_user).to_lowercase()),
-            outer_signer: Some(format!("{:#x}", self.wallet.address()).to_lowercase()),
         };
 
         let signatures = sign_typed_data_multi_sig(&send_asset, wallets)?;
@@ -1249,8 +1245,6 @@ impl ExchangeClient {
             amount: amount.to_string(),
             from_sub_account: "".to_string(),
             nonce: timestamp,
-            payload_multi_sig_user: Some(format!("{:#x}", multi_sig_user).to_lowercase()),
-            outer_signer: Some(format!("{:#x}", self.wallet.address()).to_lowercase()),
         };
 
         let signatures = sign_typed_data_multi_sig(&send_asset, wallets)?;
@@ -1299,8 +1293,6 @@ impl ExchangeClient {
     ///     amount: "100".to_string(),
     ///     from_sub_account: "".to_string(),
     ///     nonce: 123456789,
-    ///     payload_multi_sig_user: Some(format!("{:#x}", multi_sig_user).to_lowercase()),
-    ///     outer_signer: Some("0x...".to_lowercase()),
     /// };
     ///
     /// let sig1 = sign_multi_sig_user_signed_action_single(&wallet1, &send_asset)?;
@@ -1340,8 +1332,6 @@ impl ExchangeClient {
             amount: amount.to_string(),
             from_sub_account: "".to_string(),
             nonce: timestamp,
-            payload_multi_sig_user: Some(format!("{:#x}", multi_sig_user).to_lowercase()),
-            outer_signer: Some(format!("{:#x}", self.wallet.address()).to_lowercase()),
         };
 
         let mut action =
@@ -1391,8 +1381,6 @@ impl ExchangeClient {
             amount: amount.to_string(),
             from_sub_account: "".to_string(),
             nonce: timestamp,
-            payload_multi_sig_user: Some(format!("{:#x}", multi_sig_user).to_lowercase()),
-            outer_signer: Some(format!("{:#x}", self.wallet.address()).to_lowercase()),
         };
 
         let mut action =
@@ -1659,8 +1647,6 @@ mod tests {
             amount: "100".to_string(),
             from_sub_account: "".to_string(),
             nonce: 1583838,
-            payload_multi_sig_user: None,
-            outer_signer: None,
         };
 
         let mainnet_signature = sign_typed_data(&mainnet_send, &wallet)?;
@@ -1675,8 +1661,6 @@ mod tests {
             amount: "50".to_string(),
             from_sub_account: "".to_string(),
             nonce: 1583838,
-            payload_multi_sig_user: None,
-            outer_signer: None,
         };
 
         let testnet_signature = sign_typed_data(&testnet_send, &wallet)?;
@@ -1692,8 +1676,6 @@ mod tests {
             amount: "100".to_string(),
             from_sub_account: "0xabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd".to_string(),
             nonce: 1583838,
-            payload_multi_sig_user: None,
-            outer_signer: None,
         };
 
         let vault_signature = sign_typed_data(&vault_send, &wallet)?;

--- a/src/exchange/exchange_client.rs
+++ b/src/exchange/exchange_client.rs
@@ -1185,7 +1185,7 @@ impl ExchangeClient {
             "Testnet".to_string()
         };
 
-        let timestamp = 1762838147000;
+        let timestamp = next_nonce();
 
         let send_asset = SendAsset {
             signature_chain_id: 421614,

--- a/src/exchange/exchange_client.rs
+++ b/src/exchange/exchange_client.rs
@@ -976,7 +976,7 @@ impl ExchangeClient {
     ) -> Result<ExchangeResponseStatus> {
         let multi_sig_action = MultiSigAction {
             type_: "multiSig".to_string(),
-            signature_chain_id: "0x1".to_string(),
+            signature_chain_id: "0x66eee".to_string(),
             signatures: inner_signatures,
             payload: MultiSigPayload {
                 multi_sig_user: multi_sig_user.to_string().to_lowercase(),

--- a/src/exchange/exchange_client.rs
+++ b/src/exchange/exchange_client.rs
@@ -976,7 +976,7 @@ impl ExchangeClient {
     ) -> Result<ExchangeResponseStatus> {
         let multi_sig_action = MultiSigAction {
             type_: "multiSig".to_string(),
-            signature_chain_id: "0x66eee".to_string(),
+            signature_chain_id: "0x1".to_string(),
             signatures: inner_signatures,
             payload: MultiSigPayload {
                 multi_sig_user: multi_sig_user.to_string().to_lowercase(),

--- a/src/exchange/exchange_client.rs
+++ b/src/exchange/exchange_client.rs
@@ -1186,7 +1186,7 @@ impl ExchangeClient {
             "Testnet".to_string()
         };
 
-        let timestamp = 1762838147000;
+        let timestamp = next_nonce();
 
         let send_asset = SendAsset {
             signature_chain_id: 421614,

--- a/src/exchange/exchange_client.rs
+++ b/src/exchange/exchange_client.rs
@@ -29,8 +29,8 @@ use crate::{
         sign_l1_action, sign_multi_sig_action, sign_multi_sig_l1_action_payload, sign_typed_data,
         sign_typed_data_multi_sig,
     },
-    BaseUrl, BulkCancelCloid, ClassTransfer, Error, ExchangeResponseStatus, SpotSend, SpotUser,
-    VaultTransfer, Withdraw3,
+    BaseUrl, BulkCancelCloid, ClassTransfer, Error, ExchangeResponseStatus, MultiSigExtension,
+    SpotSend, SpotUser, VaultTransfer, Withdraw3,
 };
 
 #[derive(Debug)]
@@ -368,8 +368,7 @@ impl ExchangeClient {
             amount: amount.to_string(),
             from_sub_account,
             nonce: timestamp,
-            payload_multi_sig_user: None,
-            outer_signer: None,
+            multi_sig_ext: None,
         };
 
         let signature = sign_typed_data(&send_asset, wallet)?;
@@ -1206,8 +1205,10 @@ impl ExchangeClient {
             amount: amount.to_string(),
             from_sub_account: "".to_string(),
             nonce: timestamp,
-            payload_multi_sig_user: Some(format!("{:#x}", multi_sig_user).to_lowercase()),
-            outer_signer: Some(format!("{:#x}", self.wallet.address()).to_lowercase()),
+            multi_sig_ext: Some(MultiSigExtension {
+                payload_multi_sig_user: format!("{:#x}", multi_sig_user).to_lowercase(),
+                outer_signer: format!("{:#x}", self.wallet.address()).to_lowercase(),
+            }),
         };
 
         let signatures = sign_typed_data_multi_sig(&send_asset, wallets)?;
@@ -1249,8 +1250,10 @@ impl ExchangeClient {
             amount: amount.to_string(),
             from_sub_account: "".to_string(),
             nonce: timestamp,
-            payload_multi_sig_user: Some(format!("{:#x}", multi_sig_user).to_lowercase()),
-            outer_signer: Some(format!("{:#x}", self.wallet.address()).to_lowercase()),
+            multi_sig_ext: Some(MultiSigExtension {
+                payload_multi_sig_user: format!("{:#x}", multi_sig_user).to_lowercase(),
+                outer_signer: format!("{:#x}", self.wallet.address()).to_lowercase(),
+            }),
         };
 
         let signatures = sign_typed_data_multi_sig(&send_asset, wallets)?;
@@ -1299,8 +1302,10 @@ impl ExchangeClient {
     ///     amount: "100".to_string(),
     ///     from_sub_account: "".to_string(),
     ///     nonce: 123456789,
+    ///     multi_sig_ext: Some(MultiSigExtension {
     ///     payload_multi_sig_user: Some(format!("{:#x}", multi_sig_user).to_lowercase()),
-    ///     outer_signer: Some("0x...".to_lowercase()),
+    ///         outer_signer: Some("0x...".to_lowercase()),
+    ///     }),
     /// };
     ///
     /// let sig1 = sign_multi_sig_user_signed_action_single(&wallet1, &send_asset)?;
@@ -1340,8 +1345,10 @@ impl ExchangeClient {
             amount: amount.to_string(),
             from_sub_account: "".to_string(),
             nonce: timestamp,
-            payload_multi_sig_user: Some(format!("{:#x}", multi_sig_user).to_lowercase()),
-            outer_signer: Some(format!("{:#x}", self.wallet.address()).to_lowercase()),
+            multi_sig_ext: Some(MultiSigExtension {
+                payload_multi_sig_user: format!("{:#x}", multi_sig_user).to_lowercase(),
+                outer_signer: format!("{:#x}", self.wallet.address()).to_lowercase(),
+            }),
         };
 
         let mut action =
@@ -1391,8 +1398,10 @@ impl ExchangeClient {
             amount: amount.to_string(),
             from_sub_account: "".to_string(),
             nonce: timestamp,
-            payload_multi_sig_user: Some(format!("{:#x}", multi_sig_user).to_lowercase()),
-            outer_signer: Some(format!("{:#x}", self.wallet.address()).to_lowercase()),
+            multi_sig_ext: Some(MultiSigExtension {
+                payload_multi_sig_user: format!("{:#x}", multi_sig_user).to_lowercase(),
+                outer_signer: format!("{:#x}", self.wallet.address()).to_lowercase(),
+            }),
         };
 
         let mut action =
@@ -1659,8 +1668,7 @@ mod tests {
             amount: "100".to_string(),
             from_sub_account: "".to_string(),
             nonce: 1583838,
-            payload_multi_sig_user: None,
-            outer_signer: None,
+            multi_sig_ext: None,
         };
 
         let mainnet_signature = sign_typed_data(&mainnet_send, &wallet)?;
@@ -1675,8 +1683,7 @@ mod tests {
             amount: "50".to_string(),
             from_sub_account: "".to_string(),
             nonce: 1583838,
-            payload_multi_sig_user: None,
-            outer_signer: None,
+            multi_sig_ext: None,
         };
 
         let testnet_signature = sign_typed_data(&testnet_send, &wallet)?;
@@ -1692,8 +1699,7 @@ mod tests {
             amount: "100".to_string(),
             from_sub_account: "0xabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd".to_string(),
             nonce: 1583838,
-            payload_multi_sig_user: None,
-            outer_signer: None,
+            multi_sig_ext: None,
         };
 
         let vault_signature = sign_typed_data(&vault_send, &wallet)?;

--- a/src/exchange/exchange_client.rs
+++ b/src/exchange/exchange_client.rs
@@ -62,7 +62,7 @@ struct ExchangePayload {
     signature: Signature,
     nonce: u64,
     #[serde(skip_serializing_if = "Option::is_none")]
-    vault_address: Option<Address>,
+    vault_address: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     expires_after: Option<u64>,
 }
@@ -71,8 +71,8 @@ struct ExchangePayload {
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct MultiSigPayload {
-    multi_sig_user: Address,
-    outer_signer: Address,
+    multi_sig_user: String,
+    outer_signer: String,
     action: serde_json::Value,
 }
 
@@ -245,6 +245,7 @@ impl ExchangeClient {
                 None
             } else {
                 self.vault_address
+                    .map(|addr| addr.to_string().to_lowercase())
             },
             expires_after: if should_exclude {
                 None
@@ -978,8 +979,8 @@ impl ExchangeClient {
             signature_chain_id: "0x66eee".to_string(),
             signatures: inner_signatures,
             payload: MultiSigPayload {
-                multi_sig_user,
-                outer_signer: self.wallet.address(),
+                multi_sig_user: multi_sig_user.to_string().to_lowercase(),
+                outer_signer: self.wallet.address().to_string().to_lowercase(),
                 action: inner_action,
             },
         };
@@ -1800,8 +1801,8 @@ mod tests {
             signature_chain_id: "0x66eee".to_string(),
             signatures: vec![sig],
             payload: MultiSigPayload {
-                multi_sig_user,
-                outer_signer: wallet.address(),
+                multi_sig_user: multi_sig_user.to_string().to_lowercase(),
+                outer_signer: wallet.address().to_string().to_lowercase(),
                 action: inner_action,
             },
         };

--- a/src/exchange/exchange_client.rs
+++ b/src/exchange/exchange_client.rs
@@ -1217,7 +1217,7 @@ impl ExchangeClient {
         let mut action =
             serde_json::to_value(&send_asset).map_err(|e| Error::JsonParse(e.to_string()))?;
         if let Some(obj) = action.as_object_mut() {
-            obj.insert("type".to_string(), serde_json::json!("sendAsset"));
+            obj.shift_insert(0, "type".to_string(), serde_json::json!("sendAsset"));
         }
 
         self.post_multi_sig(multi_sig_user, action, signatures, timestamp)
@@ -1262,7 +1262,7 @@ impl ExchangeClient {
         let mut action =
             serde_json::to_value(&send_asset).map_err(|e| Error::JsonParse(e.to_string()))?;
         if let Some(obj) = action.as_object_mut() {
-            obj.insert("type".to_string(), serde_json::json!("sendAsset"));
+            obj.shift_insert(0, "type".to_string(), serde_json::json!("sendAsset"));
         }
 
         self.post_multi_sig(multi_sig_user, action, signatures, timestamp)
@@ -1355,7 +1355,7 @@ impl ExchangeClient {
         let mut action =
             serde_json::to_value(&send_asset).map_err(|e| Error::JsonParse(e.to_string()))?;
         if let Some(obj) = action.as_object_mut() {
-            obj.insert("type".to_string(), serde_json::json!("sendAsset"));
+            obj.shift_insert(0, "type".to_string(), serde_json::json!("sendAsset"));
         }
 
         self.post_multi_sig(multi_sig_user, action, signatures, timestamp)
@@ -1408,7 +1408,7 @@ impl ExchangeClient {
         let mut action =
             serde_json::to_value(&send_asset).map_err(|e| Error::JsonParse(e.to_string()))?;
         if let Some(obj) = action.as_object_mut() {
-            obj.insert("type".to_string(), serde_json::json!("sendAsset"));
+            obj.shift_insert(0, "type".to_string(), serde_json::json!("sendAsset"));
         }
 
         self.post_multi_sig(multi_sig_user, action, signatures, timestamp)

--- a/src/exchange/exchange_client.rs
+++ b/src/exchange/exchange_client.rs
@@ -1186,7 +1186,7 @@ impl ExchangeClient {
             "Testnet".to_string()
         };
 
-        let timestamp = next_nonce();
+        let timestamp = 1762838147000;
 
         let send_asset = SendAsset {
             signature_chain_id: 421614,

--- a/src/exchange/exchange_client.rs
+++ b/src/exchange/exchange_client.rs
@@ -1194,7 +1194,7 @@ impl ExchangeClient {
             "Testnet".to_string()
         };
 
-        let timestamp = next_nonce();
+        let timestamp = 1762838147000;
 
         let send_asset = SendAsset {
             signature_chain_id: 421614,

--- a/src/exchange/exchange_client.rs
+++ b/src/exchange/exchange_client.rs
@@ -80,7 +80,7 @@ struct MultiSigPayload {
 pub(crate) struct MultiSigAction {
     #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
     pub r#type: Option<String>,
-    signature_chain_id: String,
+    pub signature_chain_id: String,
     #[serde(serialize_with = "serialize_sigs")]
     signatures: Vec<Signature>,
     payload: MultiSigPayload,

--- a/src/exchange/mod.rs
+++ b/src/exchange/mod.rs
@@ -1,4 +1,4 @@
-mod actions;
+pub mod actions;
 mod builder;
 mod cancel;
 mod exchange_client;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,4 +19,5 @@ pub use helpers::{bps_diff, truncate_float, BaseUrl};
 pub use info::{info_client::*, *};
 pub use market_maker::{MarketMaker, MarketMakerInput, MarketMakerRestingOrder};
 pub use meta::{AssetContext, AssetMeta, Meta, MetaAndAssetCtxs, SpotAssetMeta, SpotMeta};
+pub use signature::{sign_multi_sig_l1_action_single, sign_multi_sig_user_signed_action_single};
 pub use ws::*;

--- a/src/signature/create_signature.rs
+++ b/src/signature/create_signature.rs
@@ -1,8 +1,5 @@
 use crate::{eip712::Eip712, prelude::*, signature::agent::l1, Error};
-use alloy::{
-    primitives::B256,
-    signers::{local::PrivateKeySigner, Signature, SignerSync},
-};
+use alloy::{hex, primitives::B256, signers::{local::PrivateKeySigner, Signature, SignerSync}};
 
 pub(crate) fn sign_l1_action(
     wallet: &PrivateKeySigner,
@@ -116,6 +113,7 @@ pub(crate) fn sign_multi_sig_action(
     let mut bytes = rmp_serde::to_vec_named(&action_without_type)
         .map_err(|e| Error::RmpParse(e.to_string()))?;
     println!("{}", action_without_type);
+    println!("{}", hex::encode(&bytes));
 
     bytes.extend(nonce.to_be_bytes());
 

--- a/src/signature/create_signature.rs
+++ b/src/signature/create_signature.rs
@@ -139,8 +139,19 @@ pub(crate) fn sign_multi_sig_action(
         "Testnet".to_string()
     };
 
+    let signature_chain_id = u64::from_str_radix(
+        multi_sig_action.signature_chain_id.trim_start_matches("0x"),
+        16,
+    )
+    .map_err(|_| {
+        Error::GenericParse(format!(
+            "Invalid signature chain ID: {}",
+            multi_sig_action.signature_chain_id
+        ))
+    })?;
+
     let envelope = MultiSigEnvelope {
-        signature_chain_id: 421614, // Always use this chain ID for multi-sig
+        signature_chain_id,
         hyperliquid_chain,
         multi_sig_action_hash,
         nonce,

--- a/src/signature/create_signature.rs
+++ b/src/signature/create_signature.rs
@@ -2,7 +2,6 @@ use alloy::{
     primitives::B256,
     signers::{local::PrivateKeySigner, Signature, SignerSync},
 };
-
 use crate::{eip712::Eip712, prelude::*, signature::agent::l1, Error};
 
 pub(crate) fn sign_l1_action(
@@ -115,6 +114,7 @@ pub(crate) fn sign_multi_sig_action(
 
     let mut bytes = rmp_serde::to_vec_named(&action_without_type)
         .map_err(|e| Error::RmpParse(e.to_string()))?;
+    println!("{}", action_without_type);
 
     bytes.extend(nonce.to_be_bytes());
 

--- a/src/signature/create_signature.rs
+++ b/src/signature/create_signature.rs
@@ -1,7 +1,6 @@
 use crate::exchange::MultiSigAction;
 use crate::{eip712::Eip712, prelude::*, signature::agent::l1, Actions, Error};
 use alloy::{
-    hex,
     primitives::B256,
     signers::{local::PrivateKeySigner, Signature, SignerSync},
 };
@@ -114,7 +113,6 @@ pub(crate) fn sign_multi_sig_action(
 
     let mut bytes = rmp_serde::to_vec_named(&action_without_type)
         .map_err(|e| Error::RmpParse(e.to_string()))?;
-    println!("{}", hex::encode(&bytes));
 
     bytes.extend(nonce.to_be_bytes());
 

--- a/src/signature/create_signature.rs
+++ b/src/signature/create_signature.rs
@@ -115,6 +115,7 @@ pub(crate) fn sign_multi_sig_action(
 
     let mut bytes = rmp_serde::to_vec_named(&action_without_type)
         .map_err(|e| Error::RmpParse(e.to_string()))?;
+    println!("{}", action_without_type);
 
     bytes.extend(nonce.to_be_bytes());
 

--- a/src/signature/create_signature.rs
+++ b/src/signature/create_signature.rs
@@ -115,7 +115,6 @@ pub(crate) fn sign_multi_sig_action(
 
     let mut bytes = rmp_serde::to_vec_named(&action_without_type)
         .map_err(|e| Error::RmpParse(e.to_string()))?;
-    println!("{}", action_without_type);
 
     bytes.extend(nonce.to_be_bytes());
 

--- a/src/signature/create_signature.rs
+++ b/src/signature/create_signature.rs
@@ -1,8 +1,8 @@
+use crate::{eip712::Eip712, prelude::*, signature::agent::l1, Error};
 use alloy::{
     primitives::B256,
     signers::{local::PrivateKeySigner, Signature, SignerSync},
 };
-use crate::{eip712::Eip712, prelude::*, signature::agent::l1, Error};
 
 pub(crate) fn sign_l1_action(
     wallet: &PrivateKeySigner,

--- a/src/signature/create_signature.rs
+++ b/src/signature/create_signature.rs
@@ -109,7 +109,8 @@ pub(crate) fn sign_multi_sig_action(
     // Remove the "type" field before hashing (as per Python SDK)
     let mut action_without_type = multi_sig_action.clone();
     if let Some(obj) = action_without_type.as_object_mut() {
-        obj.remove("type");
+        // Need to preserve the order of the fields
+        obj.shift_remove("type");
     }
 
     let mut bytes = rmp_serde::to_vec_named(&action_without_type)

--- a/src/signature/mod.rs
+++ b/src/signature/mod.rs
@@ -5,3 +5,8 @@ pub(crate) use create_signature::{
     sign_l1_action, sign_multi_sig_action, sign_multi_sig_l1_action_payload, sign_typed_data,
     sign_typed_data_multi_sig,
 };
+
+// Public API for multi-sig signature collection
+pub use create_signature::{
+    sign_multi_sig_l1_action_single, sign_multi_sig_user_signed_action_single,
+};

--- a/src/signature/mod.rs
+++ b/src/signature/mod.rs
@@ -2,5 +2,6 @@ pub(crate) mod agent;
 mod create_signature;
 
 pub(crate) use create_signature::{
-    sign_l1_action, sign_l1_action_multi_sig, sign_typed_data, sign_typed_data_multi_sig,
+    sign_l1_action, sign_multi_sig_action, sign_multi_sig_l1_action_payload, sign_typed_data,
+    sign_typed_data_multi_sig,
 };

--- a/src/signature/mod.rs
+++ b/src/signature/mod.rs
@@ -1,4 +1,6 @@
 pub(crate) mod agent;
 mod create_signature;
 
-pub(crate) use create_signature::{sign_l1_action, sign_typed_data};
+pub(crate) use create_signature::{
+    sign_l1_action, sign_l1_action_multi_sig, sign_typed_data, sign_typed_data_multi_sig,
+};

--- a/src/ws/ws_manager.rs
+++ b/src/ws/ws_manager.rs
@@ -197,7 +197,9 @@ impl WsManager {
                     match serde_json::to_string(&Ping { method: "ping" }) {
                         Ok(payload) => {
                             let mut writer = writer.lock().await;
-                            if let Err(err) = writer.send(protocol::Message::Text(payload)).await {
+                            if let Err(err) =
+                                writer.send(protocol::Message::Text(payload.into())).await
+                            {
                                 error!("Error pinging server: {err}")
                             }
                         }
@@ -384,7 +386,7 @@ impl WsManager {
         .map_err(|e| Error::JsonParse(e.to_string()))?;
 
         writer
-            .send(protocol::Message::Text(payload))
+            .send(protocol::Message::Text(payload.into()))
             .await
             .map_err(|e| Error::Websocket(e.to_string()))?;
         Ok(())


### PR DESCRIPTION
Related to: https://github.com/hyperliquid-dex/hyperliquid-rust-sdk/issues/143
- convert_to_multi_sig_user: Convert user to multi-sig with authorized users and threshold
- multi_sig_order: Execute multi-sig orders with JSON and typed actions
- multi_sig_register_token: Multi-sig token registration with spot deploy
- multi_sig_usd_send: Multi-sig USD transfers with signature chain parameters
