### PR TITLE
Make Eip712 trait public

### DIFF
--- a/src/eip712.rs
+++ b/src/eip712.rs
@@ -3,7 +3,7 @@ use alloy::{
     primitives::{keccak256, B256},
 };
 
-pub(crate) trait Eip712 {
+pub trait Eip712 {
     fn domain(&self) -> Eip712Domain;
     fn struct_hash(&self) -> B256;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ mod req;
 mod signature;
 mod ws;
 pub use consts::{EPSILON, LOCAL_API_URL, MAINNET_API_URL, TESTNET_API_URL};
+pub use eip712::Eip712;
 pub use errors::Error;
 pub use exchange::*;
 pub use helpers::{bps_diff, truncate_float, BaseUrl};


### PR DESCRIPTION
Exposes the Eip712 trait as part of the public API to allow external crates to implement EIP-712 message signing for Hyperliquid interactions.