### PR TITLE
Add "dex" parameter to /info "metaAndAssetCtxs" request

### DIFF
--- a/src/bin/info.rs
+++ b/src/bin/info.rs
@@ -95,7 +95,7 @@ async fn meta_example(info_client: &InfoClient) {
 async fn meta_and_asset_contexts_example(info_client: &InfoClient) {
     info!(
         "Meta and asset contexts: {:?}",
-        info_client.meta_and_asset_contexts().await.unwrap()
+        info_client.meta_and_asset_contexts(None).await.unwrap()
     );
 }
 

--- a/src/bin/ws_all_mids.rs
+++ b/src/bin/ws_all_mids.rs
@@ -14,7 +14,7 @@ async fn main() {
 
     let (sender, mut receiver) = unbounded_channel();
     let subscription_id = info_client
-        .subscribe(Subscription::AllMids, sender)
+        .subscribe(Subscription::AllMids { dex: Some("xyz".to_string()) }, sender)
         .await
         .unwrap();
 

--- a/src/bin/ws_candles.rs
+++ b/src/bin/ws_candles.rs
@@ -17,6 +17,7 @@ async fn main() {
             Subscription::Candle {
                 coin: "ETH".to_string(),
                 interval: "1m".to_string(),
+                dex: Some("xyz".to_string()),
             },
             sender,
         )

--- a/src/info/info_client.rs
+++ b/src/info/info_client.rs
@@ -55,7 +55,9 @@ pub enum InfoRequest {
         oid: u64,
     },
     Meta,
-    MetaAndAssetCtxs,
+    MetaAndAssetCtxs {
+        dex: Option<String>,
+    },
     SpotMeta,
     SpotMetaAndAssetCtxs,
     AllMids,
@@ -212,8 +214,8 @@ impl InfoClient {
         self.send_info_request(input).await
     }
 
-    pub async fn meta_and_asset_contexts(&self) -> Result<(Meta, Vec<AssetContext>)> {
-        let input = InfoRequest::MetaAndAssetCtxs;
+    pub async fn meta_and_asset_contexts(&self, dex: Option<String>) -> Result<(Meta, Vec<AssetContext>)> {
+        let input = InfoRequest::MetaAndAssetCtxs { dex };
         self.send_info_request(input).await
     }
 

--- a/src/info/info_client.rs
+++ b/src/info/info_client.rs
@@ -56,6 +56,7 @@ pub enum InfoRequest {
     },
     Meta,
     MetaAndAssetCtxs {
+        #[serde(skip_serializing_if = "Option::is_none")]
         dex: Option<String>,
     },
     SpotMeta,

--- a/src/info/info_client.rs
+++ b/src/info/info_client.rs
@@ -214,8 +214,11 @@ impl InfoClient {
         self.send_info_request(input).await
     }
 
-    pub async fn meta_and_asset_contexts(&self, dex: Option<String>) -> Result<(Meta, Vec<AssetContext>)> {
-        let input = InfoRequest::MetaAndAssetCtxs { dex };
+    pub async fn meta_and_asset_contexts(
+        &self,
+        dex: impl Into<Option<String>>,
+    ) -> Result<(Meta, Vec<AssetContext>)> {
+        let input = InfoRequest::MetaAndAssetCtxs { dex: dex.into() };
         self.send_info_request(input).await
     }
 

--- a/src/info/info_client.rs
+++ b/src/info/info_client.rs
@@ -26,6 +26,8 @@ pub struct CandleSnapshotRequest {
     interval: String,
     start_time: u64,
     end_time: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    dex: Option<String>,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
@@ -288,12 +290,24 @@ impl InfoClient {
         start_time: u64,
         end_time: u64,
     ) -> Result<Vec<CandlesSnapshotResponse>> {
+        self.candles_snapshot_with_dex(coin, interval, start_time, end_time, None).await
+    }
+
+    pub async fn candles_snapshot_with_dex(
+        &self,
+        coin: String,
+        interval: String,
+        start_time: u64,
+        end_time: u64,
+        dex: Option<String>,
+    ) -> Result<Vec<CandlesSnapshotResponse>> {
         let input = InfoRequest::CandleSnapshot {
             req: CandleSnapshotRequest {
                 coin,
                 interval,
                 start_time,
                 end_time,
+                dex,
             },
         };
         self.send_info_request(input).await

--- a/src/market_maker.rs
+++ b/src/market_maker.rs
@@ -93,7 +93,7 @@ impl MarketMaker {
 
         // Subscribe to AllMids so we can market make around the mid price
         self.info_client
-            .subscribe(Subscription::AllMids, sender)
+            .subscribe(Subscription::AllMids { dex: Some("xyz".to_string()) }, sender)
             .await
             .unwrap();
 

--- a/src/ws/ws_manager.rs
+++ b/src/ws/ws_manager.rs
@@ -54,20 +54,51 @@ pub(crate) struct WsManager {
 #[serde(tag = "type")]
 #[serde(rename_all = "camelCase")]
 pub enum Subscription {
-    AllMids,
-    Notification { user: Address },
-    WebData2 { user: Address },
-    Candle { coin: String, interval: String },
-    L2Book { coin: String },
-    Trades { coin: String },
-    OrderUpdates { user: Address },
-    UserEvents { user: Address },
-    UserFills { user: Address },
-    UserFundings { user: Address },
-    UserNonFundingLedgerUpdates { user: Address },
-    ActiveAssetCtx { coin: String },
-    ActiveAssetData { user: Address, coin: String },
-    Bbo { coin: String },
+    AllMids {
+        dex: Option<String>,
+    },
+    Notification {
+        user: Address,
+    },
+    WebData2 {
+        user: Address,
+    },
+    Candle {
+        coin: String,
+        interval: String,
+        dex: Option<String>,
+    },
+    L2Book {
+        coin: String,
+    },
+    Trades {
+        coin: String,
+    },
+    OrderUpdates {
+        user: Address,
+    },
+    UserEvents {
+        user: Address,
+    },
+    UserFills {
+        user: Address,
+    },
+    UserFundings {
+        user: Address,
+    },
+    UserNonFundingLedgerUpdates {
+        user: Address,
+    },
+    ActiveAssetCtx {
+        coin: String,
+    },
+    ActiveAssetData {
+        user: Address,
+        coin: String,
+    },
+    Bbo {
+        coin: String,
+    },
 }
 
 #[derive(Deserialize, Clone, Debug)]
@@ -228,7 +259,7 @@ impl WsManager {
 
     fn get_identifier(message: &Message) -> Result<String> {
         match message {
-            Message::AllMids(_) => serde_json::to_string(&Subscription::AllMids)
+            Message::AllMids(_) => serde_json::to_string(&Subscription::AllMids { dex: None })
                 .map_err(|e| Error::JsonParse(e.to_string())),
             Message::User(_) => Ok("userEvents".to_string()),
             Message::UserFills(fills) => serde_json::to_string(&Subscription::UserFills {
@@ -252,6 +283,7 @@ impl WsManager {
             Message::Candle(candle) => serde_json::to_string(&Subscription::Candle {
                 coin: candle.data.coin.clone(),
                 interval: candle.data.interval.clone(),
+                dex: None,
             })
             .map_err(|e| Error::JsonParse(e.to_string())),
             Message::OrderUpdates(_) => Ok("orderUpdates".to_string()),


### PR DESCRIPTION
While not shown in the [API docs](https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/info-endpoint/perpetuals#retrieve-perpetuals-asset-contexts-includes-mark-price-current-funding-open-interest-etc), in order to get the metaAndAssetCtxs for non default dexs (ie: xyz HIP-3 assets) you can and must pass a "dex" argument in the POST body.

This PR adds that  to the type for "metaAndAssetCtxs". The default for the API is an empty string which represents Hyperliquid's default dex itself. 

NOTE: this does slightly change the signature such that you need to call `.meta_and_asset_contexts(None)` once this merges, so it is a breaking change. I'm also open/happy to implement a new method `.meta_and_asset_contexts_with_dex()` to make it non-breaking

<img width="1180" height="687" alt="image" src="https://github.com/user-attachments/assets/bb31b4c8-4c55-4e0c-b199-9d14dc933d09" />
