### PR TITLE
add liquidation and builder_fee fields to TradeInfo, the API returns …

### DIFF
--- a/src/ws/sub_structs.rs
+++ b/src/ws/sub_structs.rs
@@ -54,6 +54,8 @@ pub struct TradeInfo {
     pub fee: String,
     pub fee_token: String,
     pub tid: u64,
+    pub liquidation: Option<FillLiquidation>,
+    pub builder_fee: Option<String>,
 }
 
 #[derive(Deserialize, Clone, Debug)]
@@ -71,6 +73,15 @@ pub enum UserData {
     Funding(UserFunding),
     Liquidation(Liquidation),
     NonUserCancel(Vec<NonUserCancel>),
+}
+
+
+#[derive(Deserialize, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct FillLiquidation {
+    pub liquidated_user: Option<String>,
+    pub mark_px: String,
+    pub method: String,
 }
 
 #[derive(Deserialize, Clone, Debug)]


### PR DESCRIPTION
…liquidation of shape FillLiquiation, TradeInfo corresponds to the API's WsFill (https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/websocket/subscriptions)
<img width="1570" height="1235" alt="image" src="https://github.com/user-attachments/assets/1be98b5f-9bf5-4f60-8863-0eba656ec333" />
