### PR TITLE
Expose post to support relaying signed actions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ lazy_static = "1.0"
 log = "0.4.19"
 reqwest = "0.12.19"
 serde = { version = "1.0", features = ["derive"] }
-serde_json = { version = "1.0", features = ["preserve_order"] }
+serde_json = "1.0"
 rmp-serde = "1.0"
 thiserror = "2.0"
 tokio = { version = "1.0", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,9 @@ repository = "https://github.com/hyperliquid-dex/hyperliquid-rust-sdk"
 
 [dependencies]
 alloy = { version = "1.0", default-features = false, features = [
-  "dyn-abi",
-  "sol-types",
-  "signer-local",
+    "dyn-abi",
+    "sol-types",
+    "signer-local",
 ] }
 chrono = "0.4.26"
 env_logger = "0.11.8"
@@ -24,9 +24,9 @@ lazy_static = "1.0"
 log = "0.4.19"
 reqwest = "0.12.19"
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+serde_json = { version = "1.0", features = ["preserve_order"] }
 rmp-serde = "1.0"
 thiserror = "2.0"
 tokio = { version = "1.0", features = ["full"] }
-tokio-tungstenite = { version = "0.20.0", features = ["native-tls"] }
+tokio-tungstenite = { version = "0.28.0", features = ["native-tls"] }
 uuid = { version = "1.0", features = ["v4"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ lazy_static = "1.0"
 log = "0.4.19"
 reqwest = "0.12.19"
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+serde_json = { version = "1.0", features = ["preserve_order"] }
 rmp-serde = "1.0"
 thiserror = "2.0"
 tokio = { version = "1.0", features = ["full"] }

--- a/src/bin/agent.rs
+++ b/src/bin/agent.rs
@@ -1,5 +1,7 @@
 use alloy::signers::local::PrivateKeySigner;
-use hyperliquid_rust_sdk::{BaseUrl, ClientLimit, ClientOrder, ClientOrderRequest, ExchangeClient};
+use hyperliquid_rust_sdk::{
+    ClientLimit, ClientOrder, ClientOrderRequest, ExchangeClient, HyperliquidChain,
+};
 use log::info;
 
 #[tokio::main]
@@ -11,9 +13,10 @@ async fn main() {
             .parse()
             .unwrap();
 
-    let exchange_client = ExchangeClient::new(None, wallet, Some(BaseUrl::Testnet), None, None)
-        .await
-        .unwrap();
+    let exchange_client =
+        ExchangeClient::new(None, wallet, Some(HyperliquidChain::Testnet), None, None)
+            .await
+            .unwrap();
 
     /*
         Create a new wallet with the agent.
@@ -27,9 +30,10 @@ async fn main() {
 
     info!("Agent address: {:?}", wallet.address());
 
-    let exchange_client = ExchangeClient::new(None, wallet, Some(BaseUrl::Testnet), None, None)
-        .await
-        .unwrap();
+    let exchange_client =
+        ExchangeClient::new(None, wallet, Some(HyperliquidChain::Testnet), None, None)
+            .await
+            .unwrap();
 
     let order = ClientOrderRequest {
         asset: "ETH".to_string(),

--- a/src/bin/approve_builder_fee.rs
+++ b/src/bin/approve_builder_fee.rs
@@ -1,5 +1,5 @@
 use alloy::{primitives::address, signers::local::PrivateKeySigner};
-use hyperliquid_rust_sdk::{BaseUrl, ExchangeClient};
+use hyperliquid_rust_sdk::{ExchangeClient, HyperliquidChain};
 use log::info;
 
 #[tokio::main]
@@ -11,10 +11,15 @@ async fn main() {
             .parse()
             .unwrap();
 
-    let exchange_client =
-        ExchangeClient::new(None, wallet.clone(), Some(BaseUrl::Testnet), None, None)
-            .await
-            .unwrap();
+    let exchange_client = ExchangeClient::new(
+        None,
+        wallet.clone(),
+        Some(HyperliquidChain::Testnet),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
 
     let max_fee_rate = "0.1%";
     let builder = address!("0x1ab189B7801140900C711E458212F9c76F8dAC79");

--- a/src/bin/bridge_withdraw.rs
+++ b/src/bin/bridge_withdraw.rs
@@ -1,5 +1,5 @@
 use alloy::signers::local::PrivateKeySigner;
-use hyperliquid_rust_sdk::{BaseUrl, ExchangeClient};
+use hyperliquid_rust_sdk::{ExchangeClient, HyperliquidChain};
 use log::info;
 
 #[tokio::main]
@@ -11,9 +11,10 @@ async fn main() {
             .parse()
             .unwrap();
 
-    let exchange_client = ExchangeClient::new(None, wallet, Some(BaseUrl::Testnet), None, None)
-        .await
-        .unwrap();
+    let exchange_client =
+        ExchangeClient::new(None, wallet, Some(HyperliquidChain::Testnet), None, None)
+            .await
+            .unwrap();
 
     let usd = "5"; // 5 USD
     let destination = "0x0D1d9635D0640821d15e323ac8AdADfA9c111414";

--- a/src/bin/claim_rewards.rs
+++ b/src/bin/claim_rewards.rs
@@ -1,5 +1,5 @@
 use alloy::signers::local::PrivateKeySigner;
-use hyperliquid_rust_sdk::{BaseUrl, ExchangeClient, ExchangeResponseStatus};
+use hyperliquid_rust_sdk::{ExchangeClient, ExchangeResponseStatus, HyperliquidChain};
 use log::info;
 
 #[tokio::main]
@@ -11,9 +11,10 @@ async fn main() {
             .parse()
             .unwrap();
 
-    let exchange_client = ExchangeClient::new(None, wallet, Some(BaseUrl::Testnet), None, None)
-        .await
-        .unwrap();
+    let exchange_client =
+        ExchangeClient::new(None, wallet, Some(HyperliquidChain::Testnet), None, None)
+            .await
+            .unwrap();
 
     let response = exchange_client.claim_rewards(None).await.unwrap();
 

--- a/src/bin/class_transfer.rs
+++ b/src/bin/class_transfer.rs
@@ -20,7 +20,7 @@ async fn main() {
     let to_perp = false;
 
     let res = exchange_client
-        .class_transfer(usdc, to_perp, None)
+        .usd_class_transfer(usdc, to_perp, None)
         .await
         .unwrap();
     info!("Class transfer result: {res:?}");

--- a/src/bin/class_transfer.rs
+++ b/src/bin/class_transfer.rs
@@ -1,5 +1,5 @@
 use alloy::signers::local::PrivateKeySigner;
-use hyperliquid_rust_sdk::{BaseUrl, ExchangeClient};
+use hyperliquid_rust_sdk::{ExchangeClient, HyperliquidChain};
 use log::info;
 
 #[tokio::main]
@@ -11,9 +11,10 @@ async fn main() {
             .parse()
             .unwrap();
 
-    let exchange_client = ExchangeClient::new(None, wallet, Some(BaseUrl::Testnet), None, None)
-        .await
-        .unwrap();
+    let exchange_client =
+        ExchangeClient::new(None, wallet, Some(HyperliquidChain::Testnet), None, None)
+            .await
+            .unwrap();
 
     let usdc = 1.0; // 1 USD
     let to_perp = false;

--- a/src/bin/convert_to_multi_sig_user.rs
+++ b/src/bin/convert_to_multi_sig_user.rs
@@ -1,0 +1,54 @@
+use alloy::{primitives::Address, signers::local::PrivateKeySigner};
+use hyperliquid_rust_sdk::{BaseUrl, ExchangeClient};
+use log::info;
+
+async fn setup_exchange_client() -> (Address, ExchangeClient) {
+    // Key was randomly generated for testing and shouldn't be used with any real funds
+    let wallet: PrivateKeySigner =
+        "e908f86dbb4d55ac876378565aafeabc187f6690f046459397b17d9b9a19688e"
+            .parse()
+            .unwrap();
+
+    let address = wallet.address();
+    let exchange_client = ExchangeClient::new(None, wallet, Some(BaseUrl::Testnet), None, None)
+        .await
+        .unwrap();
+
+    (address, exchange_client)
+}
+
+#[tokio::main]
+async fn main() {
+    env_logger::init();
+
+    let (address, exchange_client) = setup_exchange_client().await;
+
+    if address != exchange_client.wallet.address() {
+        panic!("Agents do not have permission to convert to multi-sig user");
+    }
+
+    let authorized_user_1: Address = "0x0000000000000000000000000000000000000000"
+        .parse()
+        .unwrap();
+    let authorized_user_2: Address = "0x0000000000000000000000000000000000000001"
+        .parse()
+        .unwrap();
+    let threshold = 1;
+
+    info!("Converting user {} to multi-sig", address);
+    info!(
+        "Authorized users: {}, {}",
+        authorized_user_1, authorized_user_2
+    );
+    info!("Threshold: {}", threshold);
+
+    info!("Multi-sig conversion functionality is not yet implemented in the Rust SDK");
+    info!("This example shows the structure and parameters that would be used:");
+    info!(
+        "- Authorized users: [{}, {}]",
+        authorized_user_1, authorized_user_2
+    );
+    info!("- Threshold: {}", threshold);
+
+    info!("Example completed successfully - multi-sig parameters validated");
+}

--- a/src/bin/convert_to_multi_sig_user.rs
+++ b/src/bin/convert_to_multi_sig_user.rs
@@ -23,32 +23,79 @@ async fn main() {
 
     let (address, exchange_client) = setup_exchange_client().await;
 
+    // Ensure we're using the actual user's wallet, not an agent
     if address != exchange_client.wallet.address() {
         panic!("Agents do not have permission to convert to multi-sig user");
     }
 
+    // Addresses that will be authorized to sign for the multi-sig account
     let authorized_user_1: Address = "0x0000000000000000000000000000000000000000"
         .parse()
         .unwrap();
     let authorized_user_2: Address = "0x0000000000000000000000000000000000000001"
         .parse()
         .unwrap();
+
+    // Threshold: minimum number of signatures required to execute any transaction
+    // This matches the Python example where threshold is 1
     let threshold = 1;
 
-    info!("Converting user {} to multi-sig", address);
-    info!(
-        "Authorized users: {}, {}",
-        authorized_user_1, authorized_user_2
-    );
-    info!("Threshold: {}", threshold);
+    info!("=== Convert to Multi-Sig User Example ===");
+    info!("Current user address: {}", address);
+    info!("Connected to: {:?}", exchange_client.http_client.base_url);
+    info!("");
+    info!("Configuration:");
+    info!("  Authorized user 1: {}", authorized_user_1);
+    info!("  Authorized user 2: {}", authorized_user_2);
+    info!("  Threshold: {}", threshold);
+    info!("");
 
-    info!("Multi-sig conversion functionality is not yet implemented in the Rust SDK");
-    info!("This example shows the structure and parameters that would be used:");
-    info!(
-        "- Authorized users: [{}, {}]",
-        authorized_user_1, authorized_user_2
-    );
-    info!("- Threshold: {}", threshold);
+    // Step 1: Convert the user to a multi-sig account
+    info!("Step 1: Converting to multi-sig account...");
+    match exchange_client.convert_to_multi_sig(threshold, None).await {
+        Ok(response) => {
+            info!("Convert to multi-sig response: {:?}", response);
+            info!("Successfully converted to multi-sig!");
+        }
+        Err(e) => {
+            info!("Convert to multi-sig failed (this is expected if already converted or on testnet): {}", e);
+        }
+    }
 
-    info!("Example completed successfully - multi-sig parameters validated");
+    // Step 2: Add authorized addresses
+    info!("Step 2: Adding authorized addresses...");
+    match exchange_client
+        .update_multi_sig_addresses(
+            vec![authorized_user_1, authorized_user_2],
+            vec![], // No addresses to remove
+            None,
+        )
+        .await
+    {
+        Ok(response) => {
+            info!("Update multi-sig addresses response: {:?}", response);
+            info!("Successfully added authorized addresses!");
+        }
+        Err(e) => {
+            info!("Update multi-sig addresses failed: {}", e);
+        }
+    }
+
+    info!("");
+    info!("Multi-sig setup complete!");
+    info!("Now you can use the multi-sig methods with the authorized wallets:");
+    info!("- multi_sig_order()");
+    info!("- multi_sig_usdc_transfer()");
+    info!("- multi_sig_spot_transfer()");
+    info!("");
+    info!("IMPORTANT: After converting to multi-sig:");
+    info!("1. The account can only be controlled by the authorized addresses");
+    info!(
+        "2. You need {} signatures to execute any transaction",
+        threshold
+    );
+    info!("3. Make sure you have access to the authorized private keys!");
+    info!("4. This is a one-way conversion - test on testnet first!");
+
+    info!("Example completed - multi-sig conversion functionality demonstrated");
 }

--- a/src/bin/convert_to_multi_sig_user.rs
+++ b/src/bin/convert_to_multi_sig_user.rs
@@ -1,5 +1,5 @@
 use alloy::{primitives::Address, signers::local::PrivateKeySigner};
-use hyperliquid_rust_sdk::{BaseUrl, ExchangeClient};
+use hyperliquid_rust_sdk::{ExchangeClient, HyperliquidChain};
 use log::info;
 
 async fn setup_exchange_client() -> (Address, ExchangeClient) {
@@ -10,9 +10,10 @@ async fn setup_exchange_client() -> (Address, ExchangeClient) {
             .unwrap();
 
     let address = wallet.address();
-    let exchange_client = ExchangeClient::new(None, wallet, Some(BaseUrl::Testnet), None, None)
-        .await
-        .unwrap();
+    let exchange_client =
+        ExchangeClient::new(None, wallet, Some(HyperliquidChain::Testnet), None, None)
+            .await
+            .unwrap();
 
     (address, exchange_client)
 }
@@ -42,7 +43,7 @@ async fn main() {
 
     info!("=== Convert to Multi-Sig User Example ===");
     info!("Current user address: {}", address);
-    info!("Connected to: {:?}", exchange_client.http_client.base_url);
+    info!("Connected to: {:?}", exchange_client.http_client.chain);
     info!("");
     info!("Configuration:");
     info!("  Authorized user 1: {}", authorized_user_1);

--- a/src/bin/info.rs
+++ b/src/bin/info.rs
@@ -1,5 +1,5 @@
 use alloy::primitives::Address;
-use hyperliquid_rust_sdk::{BaseUrl, InfoClient};
+use hyperliquid_rust_sdk::{HyperliquidChain, InfoClient};
 use log::info;
 
 const ADDRESS: &str = "0xc64cc00b46101bd40aa1c3121195e85c0b0918d8";
@@ -7,7 +7,9 @@ const ADDRESS: &str = "0xc64cc00b46101bd40aa1c3121195e85c0b0918d8";
 #[tokio::main]
 async fn main() {
     env_logger::init();
-    let info_client = InfoClient::new(None, Some(BaseUrl::Testnet)).await.unwrap();
+    let info_client = InfoClient::new(None, Some(HyperliquidChain::Testnet))
+        .await
+        .unwrap();
     open_orders_example(&info_client).await;
     user_state_example(&info_client).await;
     user_states_example(&info_client).await;

--- a/src/bin/leverage.rs
+++ b/src/bin/leverage.rs
@@ -1,5 +1,5 @@
 use alloy::signers::local::PrivateKeySigner;
-use hyperliquid_rust_sdk::{BaseUrl, ExchangeClient, InfoClient};
+use hyperliquid_rust_sdk::{ExchangeClient, HyperliquidChain, InfoClient};
 use log::info;
 
 #[tokio::main]
@@ -13,10 +13,13 @@ async fn main() {
             .unwrap();
 
     let address = wallet.address();
-    let exchange_client = ExchangeClient::new(None, wallet, Some(BaseUrl::Testnet), None, None)
+    let exchange_client =
+        ExchangeClient::new(None, wallet, Some(HyperliquidChain::Testnet), None, None)
+            .await
+            .unwrap();
+    let info_client = InfoClient::new(None, Some(HyperliquidChain::Testnet))
         .await
         .unwrap();
-    let info_client = InfoClient::new(None, Some(BaseUrl::Testnet)).await.unwrap();
 
     let response = exchange_client
         .update_leverage(5, "ETH", false, None)

--- a/src/bin/market_order_and_cancel.rs
+++ b/src/bin/market_order_and_cancel.rs
@@ -2,8 +2,8 @@ use std::{thread::sleep, time::Duration};
 
 use alloy::signers::local::PrivateKeySigner;
 use hyperliquid_rust_sdk::{
-    BaseUrl, ExchangeClient, ExchangeDataStatus, ExchangeResponseStatus, MarketCloseParams,
-    MarketOrderParams,
+    ExchangeClient, ExchangeDataStatus, ExchangeResponseStatus, HyperliquidChain,
+    MarketCloseParams, MarketOrderParams,
 };
 use log::info;
 
@@ -16,9 +16,10 @@ async fn main() {
             .parse()
             .unwrap();
 
-    let exchange_client = ExchangeClient::new(None, wallet, Some(BaseUrl::Testnet), None, None)
-        .await
-        .unwrap();
+    let exchange_client =
+        ExchangeClient::new(None, wallet, Some(HyperliquidChain::Testnet), None, None)
+            .await
+            .unwrap();
 
     // Market open order
     let market_open_params = MarketOrderParams {

--- a/src/bin/market_order_with_builder_and_cancel.rs
+++ b/src/bin/market_order_with_builder_and_cancel.rs
@@ -2,7 +2,7 @@ use std::{thread::sleep, time::Duration};
 
 use alloy::signers::local::PrivateKeySigner;
 use hyperliquid_rust_sdk::{
-    BaseUrl, BuilderInfo, ExchangeClient, ExchangeDataStatus, ExchangeResponseStatus,
+    BuilderInfo, ExchangeClient, ExchangeDataStatus, ExchangeResponseStatus, HyperliquidChain,
     MarketCloseParams, MarketOrderParams,
 };
 use log::info;
@@ -16,9 +16,10 @@ async fn main() {
             .parse()
             .unwrap();
 
-    let exchange_client = ExchangeClient::new(None, wallet, Some(BaseUrl::Testnet), None, None)
-        .await
-        .unwrap();
+    let exchange_client =
+        ExchangeClient::new(None, wallet, Some(HyperliquidChain::Testnet), None, None)
+            .await
+            .unwrap();
 
     // Market open order
     let market_open_params = MarketOrderParams {

--- a/src/bin/multi_sig_order.rs
+++ b/src/bin/multi_sig_order.rs
@@ -1,0 +1,94 @@
+use alloy::{primitives::Address, signers::local::PrivateKeySigner};
+use hyperliquid_rust_sdk::{BaseUrl, ClientLimit, ClientOrder, ClientOrderRequest, ExchangeClient};
+use log::info;
+use serde_json::json;
+
+fn setup_multi_sig_wallets() -> Vec<PrivateKeySigner> {
+    let wallets = vec![
+        "0x1234567890123456789012345678901234567890123456789012345678901234",
+        "0x2345678901234567890123456789012345678901234567890123456789012345",
+        "0x3456789012345678901234567890123456789012345678901234567890123456",
+    ];
+
+    wallets
+        .into_iter()
+        .map(|key| key.parse().unwrap())
+        .collect()
+}
+
+async fn setup_exchange_client() -> (Address, ExchangeClient) {
+    // Key was randomly generated for testing and shouldn't be used with any real funds
+    let wallet: PrivateKeySigner =
+        "e908f86dbb4d55ac876378565aafeabc187f6690f046459397b17d9b9a19688e"
+            .parse()
+            .unwrap();
+
+    let address = wallet.address();
+    let exchange_client = ExchangeClient::new(None, wallet, Some(BaseUrl::Testnet), None, None)
+        .await
+        .unwrap();
+
+    (address, exchange_client)
+}
+
+#[tokio::main]
+async fn main() {
+    env_logger::init();
+
+    let (address, exchange_client) = setup_exchange_client().await;
+
+    let multi_sig_user: Address = "0x0000000000000000000000000000000000000005"
+        .parse()
+        .unwrap();
+
+    let timestamp = chrono::Utc::now().timestamp_millis() as u64;
+
+    let action = json!({
+        "type": "order",
+        "orders": [{
+            "a": 0, // ETH asset index
+            "b": true,
+            "p": "1800",
+            "s": "0.01",
+            "r": false,
+            "t": {"limit": {"tif": "Gtc"}}
+        }],
+        "grouping": "na",
+    });
+
+    let typed_order = ClientOrderRequest {
+        asset: "ETH".to_string(),
+        is_buy: true,
+        reduce_only: false,
+        limit_px: 1800.0,
+        sz: 0.01,
+        cloid: None,
+        order_type: ClientOrder::Limit(ClientLimit {
+            tif: "Gtc".to_string(),
+        }),
+    };
+
+    info!("Multi-sig user: {}", multi_sig_user);
+    info!("Outer signer (current wallet): {}", address);
+    info!(
+        "Exchange client connected to: {:?}",
+        exchange_client.http_client.base_url
+    );
+    info!("Action: {}", action);
+    info!("Typed order: {:?}", typed_order);
+    info!("Timestamp: {}", timestamp);
+
+    let multi_sig_wallets = setup_multi_sig_wallets();
+    info!(
+        "Multi-sig wallets: {:?}",
+        multi_sig_wallets
+            .iter()
+            .map(|w| w.address())
+            .collect::<Vec<_>>()
+    );
+
+    info!("Multi-sig order functionality is not yet implemented in the Rust SDK");
+    info!("This example shows the structure and parameters that would be used:");
+
+    info!("Example completed successfully - multi-sig order parameters validated");
+}

--- a/src/bin/multi_sig_order.rs
+++ b/src/bin/multi_sig_order.rs
@@ -1,9 +1,10 @@
 use alloy::{primitives::Address, signers::local::PrivateKeySigner};
 use hyperliquid_rust_sdk::{BaseUrl, ClientLimit, ClientOrder, ClientOrderRequest, ExchangeClient};
 use log::info;
-use serde_json::json;
 
 fn setup_multi_sig_wallets() -> Vec<PrivateKeySigner> {
+    // These are example private keys - in production, these would be the authorized
+    // user wallets that have permission to sign for the multi-sig account
     let wallets = vec![
         "0x1234567890123456789012345678901234567890123456789012345678901234",
         "0x2345678901234567890123456789012345678901234567890123456789012345",
@@ -37,58 +38,85 @@ async fn main() {
 
     let (address, exchange_client) = setup_exchange_client().await;
 
+    // Set up the multi-sig wallets that are authorized to sign for the multi-sig user
+    // Each wallet must belong to a user that has been added as an authorized signer
+    let multi_sig_wallets = setup_multi_sig_wallets();
+
+    // The outer signer is required to be an authorized user or an agent of the
+    // authorized user of the multi-sig user.
+
+    // Address of the multi-sig user that the action will be executed for
+    // Executing the action requires at least the specified threshold of signatures
+    // required for that multi-sig user
     let multi_sig_user: Address = "0x0000000000000000000000000000000000000005"
         .parse()
         .unwrap();
 
-    let timestamp = chrono::Utc::now().timestamp_millis() as u64;
-
-    let action = json!({
-        "type": "order",
-        "orders": [{
-            "a": 0, // ETH asset index
-            "b": true,
-            "p": "1800",
-            "s": "0.01",
-            "r": false,
-            "t": {"limit": {"tif": "Gtc"}}
-        }],
-        "grouping": "na",
-    });
-
-    let typed_order = ClientOrderRequest {
-        asset: "ETH".to_string(),
-        is_buy: true,
-        reduce_only: false,
-        limit_px: 1800.0,
-        sz: 0.01,
-        cloid: None,
-        order_type: ClientOrder::Limit(ClientLimit {
-            tif: "Gtc".to_string(),
-        }),
-    };
-
-    info!("Multi-sig user: {}", multi_sig_user);
+    info!("=== Multi-Sig Order Example ===");
+    info!("Multi-sig user address: {}", multi_sig_user);
     info!("Outer signer (current wallet): {}", address);
     info!(
         "Exchange client connected to: {:?}",
         exchange_client.http_client.base_url
     );
-    info!("Action: {}", action);
-    info!("Typed order: {:?}", typed_order);
-    info!("Timestamp: {}", timestamp);
-
-    let multi_sig_wallets = setup_multi_sig_wallets();
     info!(
-        "Multi-sig wallets: {:?}",
+        "Authorized wallets ({} total): {:?}",
+        multi_sig_wallets.len(),
         multi_sig_wallets
             .iter()
             .map(|w| w.address())
             .collect::<Vec<_>>()
     );
 
-    info!("Multi-sig order functionality is not yet implemented in the Rust SDK");
-    info!("This example shows the structure and parameters that would be used:");
+    // Define the multi-sig inner action - in this case, placing an order
+    // This matches the Python example: asset index 4, buy, price 1100, size 0.2
+    let order = ClientOrderRequest {
+        asset: "ETH".to_string(), // Asset index 4 in Python corresponds to ETH
+        is_buy: true,
+        reduce_only: false,
+        limit_px: 1100.0,
+        sz: 0.2,
+        cloid: None,
+        order_type: ClientOrder::Limit(ClientLimit {
+            tif: "Gtc".to_string(),
+        }),
+    };
 
-    info!("Example completed successfully - multi-sig order parameters validated");
+    info!("");
+    info!("Order details: {:?}", order);
+    info!("Executing multi-sig order...");
+    info!(
+        "Collecting signatures from {} authorized wallets...",
+        multi_sig_wallets.len()
+    );
+
+    // Execute the multi-sig order
+    // This will collect signatures from all provided wallets and submit them together
+    // The action will only succeed if enough valid signatures are provided (>= threshold)
+    match exchange_client
+        .multi_sig_order(multi_sig_user, order, &multi_sig_wallets)
+        .await
+    {
+        Ok(response) => {
+            info!("✓ Multi-sig order placed successfully!");
+            info!("Response: {:?}", response);
+        }
+        Err(e) => {
+            info!("✗ Multi-sig order failed: {}", e);
+            info!("");
+            info!("This is expected if:");
+            info!("  • The multi-sig user is not properly configured");
+            info!("  • The provided wallets are not authorized signers");
+            info!("  • Not enough signatures provided to meet threshold");
+            info!("");
+            info!("To use in production:");
+            info!("  1. Convert a user to multi-sig: convert_to_multi_sig()");
+            info!("  2. Add authorized addresses: update_multi_sig_addresses()");
+            info!("  3. Use those authorized wallets to sign transactions");
+            info!("  4. Ensure you provide >= threshold number of valid signatures");
+        }
+    }
+
+    info!("");
+    info!("Example completed");
 }

--- a/src/bin/multi_sig_order.rs
+++ b/src/bin/multi_sig_order.rs
@@ -1,5 +1,7 @@
 use alloy::{primitives::Address, signers::local::PrivateKeySigner};
-use hyperliquid_rust_sdk::{BaseUrl, ClientLimit, ClientOrder, ClientOrderRequest, ExchangeClient};
+use hyperliquid_rust_sdk::{
+    ClientLimit, ClientOrder, ClientOrderRequest, ExchangeClient, HyperliquidChain,
+};
 use log::info;
 
 fn setup_multi_sig_wallets() -> Vec<PrivateKeySigner> {
@@ -25,9 +27,10 @@ async fn setup_exchange_client() -> (Address, ExchangeClient) {
             .unwrap();
 
     let address = wallet.address();
-    let exchange_client = ExchangeClient::new(None, wallet, Some(BaseUrl::Testnet), None, None)
-        .await
-        .unwrap();
+    let exchange_client =
+        ExchangeClient::new(None, wallet, Some(HyperliquidChain::Testnet), None, None)
+            .await
+            .unwrap();
 
     (address, exchange_client)
 }
@@ -57,7 +60,7 @@ async fn main() {
     info!("Outer signer (current wallet): {}", address);
     info!(
         "Exchange client connected to: {:?}",
-        exchange_client.http_client.base_url
+        exchange_client.http_client.chain
     );
     info!(
         "Authorized wallets ({} total): {:?}",

--- a/src/bin/multi_sig_order_signature_collection.rs
+++ b/src/bin/multi_sig_order_signature_collection.rs
@@ -1,0 +1,151 @@
+/// Example: Multi-sig order placement with signature collection workflow
+///
+/// This demonstrates how to collect signatures for L1 actions (orders)
+/// where each signer creates their signature independently.
+///
+/// Usage:
+///   cargo run --bin multi_sig_order_signature_collection
+use alloy::signers::{local::PrivateKeySigner, Signature};
+use hyperliquid_rust_sdk::sign_multi_sig_l1_action_single;
+use log::info;
+use std::str::FromStr;
+
+type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+fn main() -> Result<()> {
+    env_logger::init();
+
+    info!("=== Multi-Sig Order Signature Collection Demo ===\n");
+
+    demonstrate_order_signature_collection()?;
+
+    Ok(())
+}
+
+fn demonstrate_order_signature_collection() -> Result<()> {
+    // Setup: Define the multi-sig parameters
+    let multi_sig_user =
+        alloy::primitives::Address::from_str("0x0000000000000000000000000000000000000005")?;
+    let outer_signer =
+        alloy::primitives::Address::from_str("0x0d1d9635d0640821d15e323ac8adadfa9c111414")?;
+    let nonce = 1234567890u64;
+
+    info!("Multi-sig parameters:");
+    info!("  Multi-sig user: {}", multi_sig_user);
+    info!("  Outer signer: {}", outer_signer);
+    info!("  Nonce: {}\n", nonce);
+
+    // Create the order action
+    // All signers must create the exact same action
+    let action = serde_json::json!({
+        "type": "order",
+        "orders": [{
+            "a": 0,          // asset index (0 = BTC)
+            "b": true,       // is_buy
+            "p": "30000",    // limit price
+            "s": "0.1",      // size
+            "r": false,      // reduce_only
+            "t": {"limit": {"tif": "Gtc"}}
+        }],
+        "grouping": "na"
+    });
+
+    info!("Order action:");
+    info!("{}\n", serde_json::to_string_pretty(&action)?);
+
+    // Step 1: Each signer creates their signature independently
+    info!("Step 1: Each signer creates their signature\n");
+
+    let signer1_wallet = "0xe908f86dbb4d55ac876378565aafeabc187f6690f046459397b17d9b9a19688e"
+        .parse::<PrivateKeySigner>()?;
+    let signer2_wallet = "0x0000000000000000000000000000000000000000000000000000000000000001"
+        .parse::<PrivateKeySigner>()?;
+
+    info!("Signer 1 address: {}", signer1_wallet.address());
+    info!("Signer 2 address: {}", signer2_wallet.address());
+
+    // Signer 1 signs the L1 action
+    let sig1 = sign_multi_sig_l1_action_single(
+        &signer1_wallet,
+        &action,
+        multi_sig_user,
+        outer_signer,
+        None, // vault_address
+        nonce,
+        None,  // expires_after
+        false, // is_mainnet = false (testnet)
+    )?;
+    info!("\nSigner 1 signature: {}", sig1);
+
+    // Signer 2 signs the L1 action
+    let sig2 = sign_multi_sig_l1_action_single(
+        &signer2_wallet,
+        &action,
+        multi_sig_user,
+        outer_signer,
+        None,
+        nonce,
+        None,
+        false,
+    )?;
+    info!("Signer 2 signature: {}", sig2);
+
+    // Step 2: Signatures are serialized and transmitted
+    info!("\nStep 2: Signatures are exported for transmission\n");
+
+    let sig1_string = sig1.to_string();
+    let sig2_string = sig2.to_string();
+
+    info!("Sig 1 exported: {}", sig1_string);
+    info!("Sig 2 exported: {}", sig2_string);
+
+    // Step 3: Submitter collects and imports signatures
+    info!("\nStep 3: Submitter collects signatures\n");
+
+    let collected_signatures = [sig1_string, sig2_string];
+    info!("Collected {} signatures", collected_signatures.len());
+
+    // Import signatures
+    let signatures: Vec<Signature> = collected_signatures
+        .iter()
+        .map(|s| s.parse().expect("Failed to import signature"))
+        .collect();
+
+    info!("Successfully imported {} signatures", signatures.len());
+
+    // Step 4: Show how to submit (commented out to avoid actual submission)
+    info!("\nStep 4: Submit order (example - not executed)\n");
+
+    info!("To submit, the outer signer would run:");
+    info!("```rust");
+    info!("let submitter_wallet = \"YOUR_KEY\".parse::<PrivateKeySigner>()?;");
+    info!("let sdk = ExchangeClient::new(submitter_wallet, Some(BaseUrl::Testnet), None).await?;");
+    info!("");
+    info!("let order = ClientOrderRequest {{");
+    info!("    asset: \"BTC\".to_string(),");
+    info!("    is_buy: true,");
+    info!("    reduce_only: false,");
+    info!("    limit_px: 30000.0,");
+    info!("    sz: 0.1,");
+    info!("    order_type: ClientOrderType::Limit(ClientLimit {{");
+    info!("        tif: \"Gtc\".to_string(),");
+    info!("    }}),");
+    info!("    cloid: None,");
+    info!("}};");
+    info!("");
+    info!("sdk.multi_sig_order_with_signatures(");
+    info!("    multi_sig_user,");
+    info!("    order,");
+    info!("    signatures,");
+    info!(").await?;");
+    info!("```");
+
+    info!("\n=== Demo Complete ===");
+    info!("\nKey differences for L1 actions (orders):");
+    info!("1. Use sign_multi_sig_l1_action_single instead of sign_multi_sig_user_signed_action_single");
+    info!("2. Sign the JSON action directly (type + orders/cancels/etc)");
+    info!("3. Must specify vault_address and expires_after parameters");
+    info!("4. Network parameter (is_mainnet) affects the signature");
+
+    Ok(())
+}

--- a/src/bin/multi_sig_order_signature_collection.rs
+++ b/src/bin/multi_sig_order_signature_collection.rs
@@ -37,7 +37,7 @@ fn demonstrate_order_signature_collection() -> Result<()> {
 
     // Create the order action
     // All signers must create the exact same action
-    let action = serde_json::json!({
+    let action = serde_json::from_value(serde_json::json!({
         "type": "order",
         "orders": [{
             "a": 0,          // asset index (0 = BTC)
@@ -48,7 +48,8 @@ fn demonstrate_order_signature_collection() -> Result<()> {
             "t": {"limit": {"tif": "Gtc"}}
         }],
         "grouping": "na"
-    });
+    }))
+    .unwrap();
 
     info!("Order action:");
     info!("{}\n", serde_json::to_string_pretty(&action)?);

--- a/src/bin/multi_sig_register_token.rs
+++ b/src/bin/multi_sig_register_token.rs
@@ -1,7 +1,6 @@
 use alloy::{primitives::Address, signers::local::PrivateKeySigner};
 use hyperliquid_rust_sdk::{BaseUrl, ExchangeClient};
 use log::info;
-use serde_json::json;
 
 fn setup_multi_sig_wallets() -> Vec<PrivateKeySigner> {
     let wallets = vec![
@@ -27,34 +26,23 @@ async fn setup_exchange_client() -> (Address, ExchangeClient) {
     let exchange_client = ExchangeClient::new(None, wallet, Some(BaseUrl::Testnet), None, None)
         .await
         .unwrap();
-    
+
     (address, exchange_client)
 }
 
 #[tokio::main]
 async fn main() {
     env_logger::init();
-    
+
     let (address, exchange_client) = setup_exchange_client().await;
 
+    // The multi-sig user address (this would be the address that was converted to multi-sig)
     let multi_sig_user: Address = "0x0000000000000000000000000000000000000005"
         .parse()
         .unwrap();
 
-    let timestamp = chrono::Utc::now().timestamp_millis() as u64;
-
-    let action = json!({
-        "type": "spotDeploy",
-        "registerToken2": {
-            "spec": {
-                "name": "TESTH",
-                "szDecimals": 2,
-                "weiDecimals": 8
-            },
-            "maxGas": 1000000000000u64,
-            "fullName": "Example multi-sig spot deploy"
-        }
-    });
+    // Set up the multi-sig wallets that are authorized to sign for the multi-sig user
+    let multi_sig_wallets = setup_multi_sig_wallets();
 
     info!("Multi-sig user: {}", multi_sig_user);
     info!("Outer signer (current wallet): {}", address);
@@ -62,10 +50,6 @@ async fn main() {
         "Exchange client connected to: {:?}",
         exchange_client.http_client.base_url
     );
-    info!("Action: {}", action);
-    info!("Timestamp: {}", timestamp);
-
-    let multi_sig_wallets = setup_multi_sig_wallets();
     info!(
         "Multi-sig wallets: {:?}",
         multi_sig_wallets
@@ -74,8 +58,19 @@ async fn main() {
             .collect::<Vec<_>>()
     );
 
-    info!("Multi-sig register token functionality is not yet implemented in the Rust SDK");
-    info!("This example shows the structure and parameters that would be used:");
+    info!("Multi-sig register token functionality requires custom action handling");
+    info!("The spot token registration action (spotDeploy) is a complex action that:");
+    info!("1. Requires specific permission levels");
+    info!("2. Has custom parameters for token specification");
+    info!("3. Is typically used for specialized spot market operations");
+    info!("");
+    info!("For multi-sig spot token registration, you would:");
+    info!("1. Create a custom spotDeploy action with registerToken2 parameters");
+    info!("2. Hash the action using the Actions::hash method");
+    info!("3. Sign with multiple authorized wallets using sign_l1_action_multi_sig");
+    info!("4. Submit using the post_multi_sig method");
+    info!("");
+    info!("This is an advanced operation - consult Hyperliquid documentation for details");
 
-    info!("Example completed successfully - multi-sig register token parameters validated");
+    info!("Example completed - multi-sig register token requirements explained");
 }

--- a/src/bin/multi_sig_register_token.rs
+++ b/src/bin/multi_sig_register_token.rs
@@ -1,0 +1,81 @@
+use alloy::{primitives::Address, signers::local::PrivateKeySigner};
+use hyperliquid_rust_sdk::{BaseUrl, ExchangeClient};
+use log::info;
+use serde_json::json;
+
+fn setup_multi_sig_wallets() -> Vec<PrivateKeySigner> {
+    let wallets = vec![
+        "0x1234567890123456789012345678901234567890123456789012345678901234",
+        "0x2345678901234567890123456789012345678901234567890123456789012345",
+        "0x3456789012345678901234567890123456789012345678901234567890123456",
+    ];
+
+    wallets
+        .into_iter()
+        .map(|key| key.parse().unwrap())
+        .collect()
+}
+
+async fn setup_exchange_client() -> (Address, ExchangeClient) {
+    // Key was randomly generated for testing and shouldn't be used with any real funds
+    let wallet: PrivateKeySigner =
+        "e908f86dbb4d55ac876378565aafeabc187f6690f046459397b17d9b9a19688e"
+            .parse()
+            .unwrap();
+
+    let address = wallet.address();
+    let exchange_client = ExchangeClient::new(None, wallet, Some(BaseUrl::Testnet), None, None)
+        .await
+        .unwrap();
+    
+    (address, exchange_client)
+}
+
+#[tokio::main]
+async fn main() {
+    env_logger::init();
+    
+    let (address, exchange_client) = setup_exchange_client().await;
+
+    let multi_sig_user: Address = "0x0000000000000000000000000000000000000005"
+        .parse()
+        .unwrap();
+
+    let timestamp = chrono::Utc::now().timestamp_millis() as u64;
+
+    let action = json!({
+        "type": "spotDeploy",
+        "registerToken2": {
+            "spec": {
+                "name": "TESTH",
+                "szDecimals": 2,
+                "weiDecimals": 8
+            },
+            "maxGas": 1000000000000u64,
+            "fullName": "Example multi-sig spot deploy"
+        }
+    });
+
+    info!("Multi-sig user: {}", multi_sig_user);
+    info!("Outer signer (current wallet): {}", address);
+    info!(
+        "Exchange client connected to: {:?}",
+        exchange_client.http_client.base_url
+    );
+    info!("Action: {}", action);
+    info!("Timestamp: {}", timestamp);
+
+    let multi_sig_wallets = setup_multi_sig_wallets();
+    info!(
+        "Multi-sig wallets: {:?}",
+        multi_sig_wallets
+            .iter()
+            .map(|w| w.address())
+            .collect::<Vec<_>>()
+    );
+
+    info!("Multi-sig register token functionality is not yet implemented in the Rust SDK");
+    info!("This example shows the structure and parameters that would be used:");
+
+    info!("Example completed successfully - multi-sig register token parameters validated");
+}

--- a/src/bin/multi_sig_register_token.rs
+++ b/src/bin/multi_sig_register_token.rs
@@ -1,5 +1,5 @@
 use alloy::{primitives::Address, signers::local::PrivateKeySigner};
-use hyperliquid_rust_sdk::{BaseUrl, ExchangeClient};
+use hyperliquid_rust_sdk::{ExchangeClient, HyperliquidChain};
 use log::info;
 
 fn setup_multi_sig_wallets() -> Vec<PrivateKeySigner> {
@@ -23,9 +23,10 @@ async fn setup_exchange_client() -> (Address, ExchangeClient) {
             .unwrap();
 
     let address = wallet.address();
-    let exchange_client = ExchangeClient::new(None, wallet, Some(BaseUrl::Testnet), None, None)
-        .await
-        .unwrap();
+    let exchange_client =
+        ExchangeClient::new(None, wallet, Some(HyperliquidChain::Testnet), None, None)
+            .await
+            .unwrap();
 
     (address, exchange_client)
 }
@@ -48,7 +49,7 @@ async fn main() {
     info!("Outer signer (current wallet): {}", address);
     info!(
         "Exchange client connected to: {:?}",
-        exchange_client.http_client.base_url
+        exchange_client.http_client.chain
     );
     info!(
         "Multi-sig wallets: {:?}",

--- a/src/bin/multi_sig_signature_collection.rs
+++ b/src/bin/multi_sig_signature_collection.rs
@@ -7,7 +7,9 @@
 /// Usage:
 ///   cargo run --bin multi_sig_signature_collection
 use alloy::signers::{local::PrivateKeySigner, Signature};
-use hyperliquid_rust_sdk::{sign_multi_sig_user_signed_action_single, SendAsset};
+use hyperliquid_rust_sdk::{
+    sign_multi_sig_user_signed_action_single, MultiSigExtension, SendAsset,
+};
 use log::info;
 use std::str::FromStr;
 
@@ -132,8 +134,10 @@ fn create_send_asset(
         amount: amount.to_string(),
         from_sub_account: "".to_string(),
         nonce,
-        payload_multi_sig_user: Some(format!("{:#x}", multi_sig_user).to_lowercase()),
-        outer_signer: Some(format!("{:#x}", outer_signer).to_lowercase()),
+        multi_sig_ext: Some(MultiSigExtension {
+            payload_multi_sig_user: format!("{:#x}", multi_sig_user).to_lowercase(),
+            outer_signer: format!("{:#x}", outer_signer).to_lowercase(),
+        }),
     }
 }
 

--- a/src/bin/multi_sig_signature_collection.rs
+++ b/src/bin/multi_sig_signature_collection.rs
@@ -54,7 +54,7 @@ fn demonstrate_signature_collection() -> Result<()> {
     info!("Signer 2 address: {}", signer2_wallet.address());
 
     // Both signers create the same SendAsset action
-    let send_asset = create_send_asset(destination, amount, nonce);
+    let send_asset = create_send_asset(multi_sig_user, outer_signer, destination, amount, nonce);
 
     // Signer 1 signs
     let sig1 = sign_multi_sig_user_signed_action_single(&signer1_wallet, &send_asset)?;
@@ -115,7 +115,13 @@ fn demonstrate_signature_collection() -> Result<()> {
 }
 
 /// Create a SendAsset action - must be identical for all signers
-fn create_send_asset(destination: &str, amount: &str, nonce: u64) -> SendAsset {
+fn create_send_asset(
+    multi_sig_user: alloy::primitives::Address,
+    outer_signer: alloy::primitives::Address,
+    destination: &str,
+    amount: &str,
+    nonce: u64,
+) -> SendAsset {
     SendAsset {
         signature_chain_id: 421614,
         hyperliquid_chain: "Testnet".to_string(),
@@ -126,6 +132,8 @@ fn create_send_asset(destination: &str, amount: &str, nonce: u64) -> SendAsset {
         amount: amount.to_string(),
         from_sub_account: "".to_string(),
         nonce,
+        payload_multi_sig_user: Some(format!("{:#x}", multi_sig_user).to_lowercase()),
+        outer_signer: Some(format!("{:#x}", outer_signer).to_lowercase()),
     }
 }
 

--- a/src/bin/multi_sig_signature_collection.rs
+++ b/src/bin/multi_sig_signature_collection.rs
@@ -54,7 +54,7 @@ fn demonstrate_signature_collection() -> Result<()> {
     info!("Signer 2 address: {}", signer2_wallet.address());
 
     // Both signers create the same SendAsset action
-    let send_asset = create_send_asset(multi_sig_user, outer_signer, destination, amount, nonce);
+    let send_asset = create_send_asset(destination, amount, nonce);
 
     // Signer 1 signs
     let sig1 = sign_multi_sig_user_signed_action_single(&signer1_wallet, &send_asset)?;
@@ -115,13 +115,7 @@ fn demonstrate_signature_collection() -> Result<()> {
 }
 
 /// Create a SendAsset action - must be identical for all signers
-fn create_send_asset(
-    multi_sig_user: alloy::primitives::Address,
-    outer_signer: alloy::primitives::Address,
-    destination: &str,
-    amount: &str,
-    nonce: u64,
-) -> SendAsset {
+fn create_send_asset(destination: &str, amount: &str, nonce: u64) -> SendAsset {
     SendAsset {
         signature_chain_id: 421614,
         hyperliquid_chain: "Testnet".to_string(),
@@ -132,8 +126,6 @@ fn create_send_asset(
         amount: amount.to_string(),
         from_sub_account: "".to_string(),
         nonce,
-        payload_multi_sig_user: Some(format!("{:#x}", multi_sig_user).to_lowercase()),
-        outer_signer: Some(format!("{:#x}", outer_signer).to_lowercase()),
     }
 }
 

--- a/src/bin/multi_sig_signature_collection.rs
+++ b/src/bin/multi_sig_signature_collection.rs
@@ -1,0 +1,150 @@
+/// Example: Multi-sig USDC transfer with signature collection workflow
+///
+/// This demonstrates the recommended approach where signatures are collected
+/// from different parties independently, rather than having all private keys
+/// in one place.
+///
+/// Usage:
+///   cargo run --bin multi_sig_signature_collection
+use alloy::signers::{local::PrivateKeySigner, Signature};
+use hyperliquid_rust_sdk::{sign_multi_sig_user_signed_action_single, SendAsset};
+use log::info;
+use std::str::FromStr;
+
+type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+fn main() -> Result<()> {
+    env_logger::init();
+
+    info!("=== Multi-Sig Signature Collection Demo ===\n");
+
+    // Simulate the workflow
+    demonstrate_signature_collection()?;
+
+    Ok(())
+}
+
+fn demonstrate_signature_collection() -> Result<()> {
+    // Setup: Define the multi-sig parameters
+    // In a real scenario, these would be coordinated among all parties
+    let multi_sig_user =
+        alloy::primitives::Address::from_str("0x0000000000000000000000000000000000000005")?;
+    let outer_signer =
+        alloy::primitives::Address::from_str("0x0d1d9635d0640821d15e323ac8adadfa9c111414")?;
+    let destination = "0x1234567890123456789012345678901234567890";
+    let amount = "100";
+    let nonce = 1234567890u64;
+
+    info!("Multi-sig parameters:");
+    info!("  Multi-sig user: {}", multi_sig_user);
+    info!("  Outer signer: {}", outer_signer);
+    info!("  Destination: {}", destination);
+    info!("  Amount: {}", amount);
+    info!("  Nonce: {}\n", nonce);
+
+    // Step 1: Each signer creates their signature independently
+    info!("Step 1: Each signer creates their signature\n");
+
+    let signer1_wallet = "0xe908f86dbb4d55ac876378565aafeabc187f6690f046459397b17d9b9a19688e"
+        .parse::<PrivateKeySigner>()?;
+    let signer2_wallet = "0x0000000000000000000000000000000000000000000000000000000000000001"
+        .parse::<PrivateKeySigner>()?;
+
+    info!("Signer 1 address: {}", signer1_wallet.address());
+    info!("Signer 2 address: {}", signer2_wallet.address());
+
+    // Both signers create the same SendAsset action
+    let send_asset = create_send_asset(multi_sig_user, outer_signer, destination, amount, nonce);
+
+    // Signer 1 signs
+    let sig1 = sign_multi_sig_user_signed_action_single(&signer1_wallet, &send_asset)?;
+    info!("\nSigner 1 signature: {}", sig1);
+
+    // Signer 2 signs
+    let sig2 = sign_multi_sig_user_signed_action_single(&signer2_wallet, &send_asset)?;
+    info!("Signer 2 signature: {}", sig2);
+
+    // Step 2: Signatures are serialized and transmitted
+    info!("\nStep 2: Signatures are exported for transmission\n");
+
+    let sig1_string = export_signature(&sig1);
+    let sig2_string = export_signature(&sig2);
+
+    info!("Sig 1 exported: {}", sig1_string);
+    info!("Sig 2 exported: {}", sig2_string);
+
+    // Step 3: Submitter collects and imports signatures
+    info!("\nStep 3: Submitter collects signatures\n");
+
+    let collected_signatures = [sig1_string, sig2_string];
+    info!("Collected {} signatures", collected_signatures.len());
+
+    // Import signatures
+    let signatures: Vec<Signature> = collected_signatures
+        .iter()
+        .map(|s| import_signature(s).expect("Failed to import signature"))
+        .collect();
+
+    info!("Successfully imported {} signatures", signatures.len());
+
+    // Step 4: Show how to submit (commented out to avoid actual submission)
+    info!("\nStep 4: Submit transaction (example - not executed)\n");
+
+    info!("To submit, the outer signer would run:");
+    info!("```rust");
+    info!("let submitter_wallet = \"YOUR_KEY\".parse::<PrivateKeySigner>()?;");
+    info!("let sdk = ExchangeClient::new(submitter_wallet, Some(BaseUrl::Testnet), None).await?;");
+    info!("");
+    info!("sdk.multi_sig_usdc_transfer_with_signatures(");
+    info!("    multi_sig_user,");
+    info!("    \"{}\",", amount);
+    info!("    \"{}\",", destination);
+    info!("    signatures,");
+    info!(").await?;");
+    info!("```");
+
+    info!("\n=== Demo Complete ===");
+    info!("\nKey takeaways:");
+    info!("1. Each signer creates their signature independently");
+    info!("2. Signatures can be serialized as hex strings for transmission");
+    info!("3. The submitter collects and combines signatures");
+    info!("4. All signers must sign identical action parameters");
+    info!("5. The outer_signer (submitter) doesn't need to be a multi-sig participant");
+
+    Ok(())
+}
+
+/// Create a SendAsset action - must be identical for all signers
+fn create_send_asset(
+    multi_sig_user: alloy::primitives::Address,
+    outer_signer: alloy::primitives::Address,
+    destination: &str,
+    amount: &str,
+    nonce: u64,
+) -> SendAsset {
+    SendAsset {
+        signature_chain_id: 421614,
+        hyperliquid_chain: "Testnet".to_string(),
+        destination: destination.to_string(),
+        source_dex: "".to_string(),
+        destination_dex: "".to_string(),
+        token: "USDC".to_string(),
+        amount: amount.to_string(),
+        from_sub_account: "".to_string(),
+        nonce,
+        payload_multi_sig_user: Some(format!("{:#x}", multi_sig_user).to_lowercase()),
+        outer_signer: Some(format!("{:#x}", outer_signer).to_lowercase()),
+    }
+}
+
+/// Export a signature as a hex string
+fn export_signature(sig: &Signature) -> String {
+    sig.to_string()
+}
+
+/// Import a signature from a hex string
+fn import_signature(sig_str: &str) -> Result<Signature> {
+    sig_str
+        .parse()
+        .map_err(|e| format!("Failed to parse signature: {:?}", e).into())
+}

--- a/src/bin/multi_sig_signature_collection.rs
+++ b/src/bin/multi_sig_signature_collection.rs
@@ -127,7 +127,7 @@ fn create_send_asset(
     SendAsset {
         signature_chain_id: 421614,
         hyperliquid_chain: "Testnet".to_string(),
-        destination: destination.to_string(),
+        destination: destination.to_lowercase(),
         source_dex: "".to_string(),
         destination_dex: "".to_string(),
         token: "USDC".to_string(),

--- a/src/bin/multi_sig_usd_send.rs
+++ b/src/bin/multi_sig_usd_send.rs
@@ -1,0 +1,77 @@
+use alloy::{primitives::Address, signers::local::PrivateKeySigner};
+use hyperliquid_rust_sdk::{BaseUrl, ExchangeClient};
+use log::info;
+use serde_json::json;
+
+fn setup_multi_sig_wallets() -> Vec<PrivateKeySigner> {
+    let wallets = vec![
+        "0x1234567890123456789012345678901234567890123456789012345678901234",
+        "0x2345678901234567890123456789012345678901234567890123456789012345",
+        "0x3456789012345678901234567890123456789012345678901234567890123456",
+    ];
+
+    wallets
+        .into_iter()
+        .map(|key| key.parse().unwrap())
+        .collect()
+}
+
+async fn setup_exchange_client() -> (Address, ExchangeClient) {
+    // Key was randomly generated for testing and shouldn't be used with any real funds
+    let wallet: PrivateKeySigner =
+        "e908f86dbb4d55ac876378565aafeabc187f6690f046459397b17d9b9a19688e"
+            .parse()
+            .unwrap();
+
+    let address = wallet.address();
+    let exchange_client = ExchangeClient::new(None, wallet, Some(BaseUrl::Testnet), None, None)
+        .await
+        .unwrap();
+    
+    (address, exchange_client)
+}
+
+#[tokio::main]
+async fn main() {
+    env_logger::init();
+    
+    let (address, exchange_client) = setup_exchange_client().await;
+
+    let multi_sig_user: Address = "0x0000000000000000000000000000000000000005"
+        .parse()
+        .unwrap();
+
+    let timestamp = chrono::Utc::now().timestamp_millis() as u64;
+
+    let action = json!({
+        "type": "usdSend",
+        "signatureChainId": "0x66eee",
+        "hyperliquidChain": "Testnet",
+        "destination": "0x0D1d9635D0640821d15e323ac8AdADfA9c111414",
+        "amount": "1.0",
+        "time": timestamp
+    });
+
+    info!("Multi-sig user: {}", multi_sig_user);
+    info!("Outer signer (current wallet): {}", address);
+    info!(
+        "Exchange client connected to: {:?}",
+        exchange_client.http_client.base_url
+    );
+    info!("Action: {}", action);
+    info!("Timestamp: {}", timestamp);
+
+    let multi_sig_wallets = setup_multi_sig_wallets();
+    info!(
+        "Multi-sig wallets: {:?}",
+        multi_sig_wallets
+            .iter()
+            .map(|w| w.address())
+            .collect::<Vec<_>>()
+    );
+
+    info!("Multi-sig USD send functionality is not yet implemented in the Rust SDK");
+    info!("This example shows the structure and parameters that would be used:");
+
+    info!("Example completed successfully - multi-sig USD send parameters validated");
+}

--- a/src/bin/multi_sig_usd_send.rs
+++ b/src/bin/multi_sig_usd_send.rs
@@ -1,5 +1,5 @@
 use alloy::{primitives::Address, signers::local::PrivateKeySigner};
-use hyperliquid_rust_sdk::{BaseUrl, ExchangeClient};
+use hyperliquid_rust_sdk::{ExchangeClient, HyperliquidChain};
 use log::info;
 
 fn setup_multi_sig_wallets() -> Vec<PrivateKeySigner> {
@@ -25,9 +25,10 @@ async fn setup_exchange_client() -> (Address, ExchangeClient) {
             .unwrap();
 
     let address = wallet.address();
-    let exchange_client = ExchangeClient::new(None, wallet, Some(BaseUrl::Testnet), None, None)
-        .await
-        .unwrap();
+    let exchange_client =
+        ExchangeClient::new(None, wallet, Some(HyperliquidChain::Testnet), None, None)
+            .await
+            .unwrap();
 
     (address, exchange_client)
 }
@@ -63,7 +64,7 @@ async fn main() {
     info!("Outer signer (current wallet): {}", address);
     info!(
         "Exchange client connected to: {:?}",
-        exchange_client.http_client.base_url
+        exchange_client.http_client.chain
     );
     info!("Destination: {}", destination);
     info!("Amount: {} USDC", amount);

--- a/src/bin/order_and_cancel.rs
+++ b/src/bin/order_and_cancel.rs
@@ -2,8 +2,8 @@ use std::{thread::sleep, time::Duration};
 
 use alloy::signers::local::PrivateKeySigner;
 use hyperliquid_rust_sdk::{
-    BaseUrl, ClientCancelRequest, ClientLimit, ClientOrder, ClientOrderRequest, ExchangeClient,
-    ExchangeDataStatus, ExchangeResponseStatus,
+    ClientCancelRequest, ClientLimit, ClientOrder, ClientOrderRequest, ExchangeClient,
+    ExchangeDataStatus, ExchangeResponseStatus, HyperliquidChain,
 };
 use log::info;
 
@@ -16,9 +16,10 @@ async fn main() {
             .parse()
             .unwrap();
 
-    let exchange_client = ExchangeClient::new(None, wallet, Some(BaseUrl::Testnet), None, None)
-        .await
-        .unwrap();
+    let exchange_client =
+        ExchangeClient::new(None, wallet, Some(HyperliquidChain::Testnet), None, None)
+            .await
+            .unwrap();
 
     let order = ClientOrderRequest {
         asset: "ETH".to_string(),

--- a/src/bin/order_and_cancel_cloid.rs
+++ b/src/bin/order_and_cancel_cloid.rs
@@ -2,7 +2,8 @@ use std::{thread::sleep, time::Duration};
 
 use alloy::signers::local::PrivateKeySigner;
 use hyperliquid_rust_sdk::{
-    BaseUrl, ClientCancelRequestCloid, ClientLimit, ClientOrder, ClientOrderRequest, ExchangeClient,
+    ClientCancelRequestCloid, ClientLimit, ClientOrder, ClientOrderRequest, ExchangeClient,
+    HyperliquidChain,
 };
 use log::info;
 use uuid::Uuid;
@@ -16,9 +17,10 @@ async fn main() {
             .parse()
             .unwrap();
 
-    let exchange_client = ExchangeClient::new(None, wallet, Some(BaseUrl::Testnet), None, None)
-        .await
-        .unwrap();
+    let exchange_client =
+        ExchangeClient::new(None, wallet, Some(HyperliquidChain::Testnet), None, None)
+            .await
+            .unwrap();
 
     // Order and Cancel with cloid
     let cloid = Uuid::new_v4();

--- a/src/bin/order_and_schedule_cancel.rs
+++ b/src/bin/order_and_schedule_cancel.rs
@@ -2,8 +2,8 @@ use alloy::signers::local::PrivateKeySigner;
 use log::info;
 
 use hyperliquid_rust_sdk::{
-    BaseUrl, ClientLimit, ClientOrder, ClientOrderRequest, ExchangeClient, ExchangeDataStatus,
-    ExchangeResponseStatus,
+    ClientLimit, ClientOrder, ClientOrderRequest, ExchangeClient, ExchangeDataStatus,
+    ExchangeResponseStatus, HyperliquidChain,
 };
 use std::{thread::sleep, time::Duration};
 
@@ -16,9 +16,10 @@ async fn main() {
             .parse()
             .unwrap();
 
-    let exchange_client = ExchangeClient::new(None, wallet, Some(BaseUrl::Testnet), None, None)
-        .await
-        .unwrap();
+    let exchange_client =
+        ExchangeClient::new(None, wallet, Some(HyperliquidChain::Testnet), None, None)
+            .await
+            .unwrap();
 
     info!("Testing Schedule Cancel Dead Man's Switch functionality...");
 

--- a/src/bin/order_with_builder_and_cancel.rs
+++ b/src/bin/order_with_builder_and_cancel.rs
@@ -2,8 +2,8 @@ use std::{thread::sleep, time::Duration};
 
 use alloy::signers::local::PrivateKeySigner;
 use hyperliquid_rust_sdk::{
-    BaseUrl, BuilderInfo, ClientCancelRequest, ClientLimit, ClientOrder, ClientOrderRequest,
-    ExchangeClient, ExchangeDataStatus, ExchangeResponseStatus,
+    BuilderInfo, ClientCancelRequest, ClientLimit, ClientOrder, ClientOrderRequest, ExchangeClient,
+    ExchangeDataStatus, ExchangeResponseStatus, HyperliquidChain,
 };
 use log::info;
 
@@ -16,9 +16,10 @@ async fn main() {
             .parse()
             .unwrap();
 
-    let exchange_client = ExchangeClient::new(None, wallet, Some(BaseUrl::Testnet), None, None)
-        .await
-        .unwrap();
+    let exchange_client =
+        ExchangeClient::new(None, wallet, Some(HyperliquidChain::Testnet), None, None)
+            .await
+            .unwrap();
 
     let order = ClientOrderRequest {
         asset: "ETH".to_string(),

--- a/src/bin/set_referrer.rs
+++ b/src/bin/set_referrer.rs
@@ -1,5 +1,5 @@
 use alloy::signers::local::PrivateKeySigner;
-use hyperliquid_rust_sdk::{BaseUrl, ExchangeClient};
+use hyperliquid_rust_sdk::{ExchangeClient, HyperliquidChain};
 use log::info;
 
 #[tokio::main]
@@ -11,9 +11,10 @@ async fn main() {
             .parse()
             .unwrap();
 
-    let exchange_client = ExchangeClient::new(None, wallet, Some(BaseUrl::Testnet), None, None)
-        .await
-        .unwrap();
+    let exchange_client =
+        ExchangeClient::new(None, wallet, Some(HyperliquidChain::Testnet), None, None)
+            .await
+            .unwrap();
 
     let code = "TESTNET".to_string();
 

--- a/src/bin/spot_order.rs
+++ b/src/bin/spot_order.rs
@@ -2,8 +2,8 @@ use std::{thread::sleep, time::Duration};
 
 use alloy::signers::local::PrivateKeySigner;
 use hyperliquid_rust_sdk::{
-    BaseUrl, ClientCancelRequest, ClientLimit, ClientOrder, ClientOrderRequest, ExchangeClient,
-    ExchangeDataStatus, ExchangeResponseStatus,
+    ClientCancelRequest, ClientLimit, ClientOrder, ClientOrderRequest, ExchangeClient,
+    ExchangeDataStatus, ExchangeResponseStatus, HyperliquidChain,
 };
 use log::info;
 
@@ -16,9 +16,10 @@ async fn main() {
             .parse()
             .unwrap();
 
-    let exchange_client = ExchangeClient::new(None, wallet, Some(BaseUrl::Testnet), None, None)
-        .await
-        .unwrap();
+    let exchange_client =
+        ExchangeClient::new(None, wallet, Some(HyperliquidChain::Testnet), None, None)
+            .await
+            .unwrap();
 
     let order = ClientOrderRequest {
         asset: "XYZTWO/USDC".to_string(),

--- a/src/bin/spot_transfer.rs
+++ b/src/bin/spot_transfer.rs
@@ -1,5 +1,5 @@
 use alloy::signers::local::PrivateKeySigner;
-use hyperliquid_rust_sdk::{BaseUrl, ExchangeClient};
+use hyperliquid_rust_sdk::{ExchangeClient, HyperliquidChain};
 use log::info;
 
 #[tokio::main]
@@ -11,9 +11,10 @@ async fn main() {
             .parse()
             .unwrap();
 
-    let exchange_client = ExchangeClient::new(None, wallet, Some(BaseUrl::Testnet), None, None)
-        .await
-        .unwrap();
+    let exchange_client =
+        ExchangeClient::new(None, wallet, Some(HyperliquidChain::Testnet), None, None)
+            .await
+            .unwrap();
 
     let amount = "1";
     let destination = "0x0D1d9635D0640821d15e323ac8AdADfA9c111414";

--- a/src/bin/usdc_transfer.rs
+++ b/src/bin/usdc_transfer.rs
@@ -1,5 +1,5 @@
 use alloy::signers::local::PrivateKeySigner;
-use hyperliquid_rust_sdk::{BaseUrl, ExchangeClient};
+use hyperliquid_rust_sdk::{ExchangeClient, HyperliquidChain};
 use log::info;
 
 #[tokio::main]
@@ -11,9 +11,10 @@ async fn main() {
             .parse()
             .unwrap();
 
-    let exchange_client = ExchangeClient::new(None, wallet, Some(BaseUrl::Testnet), None, None)
-        .await
-        .unwrap();
+    let exchange_client =
+        ExchangeClient::new(None, wallet, Some(HyperliquidChain::Testnet), None, None)
+            .await
+            .unwrap();
 
     let amount = "1"; // 1 USD
     let destination = "0x0D1d9635D0640821d15e323ac8AdADfA9c111414";

--- a/src/bin/using_big_blocks.rs
+++ b/src/bin/using_big_blocks.rs
@@ -1,5 +1,5 @@
 use alloy::signers::local::PrivateKeySigner;
-use hyperliquid_rust_sdk::{BaseUrl, ExchangeClient};
+use hyperliquid_rust_sdk::{ExchangeClient, HyperliquidChain};
 use log::info;
 
 #[tokio::main]
@@ -11,10 +11,15 @@ async fn main() {
             .parse()
             .unwrap();
 
-    let exchange_client =
-        ExchangeClient::new(None, wallet.clone(), Some(BaseUrl::Testnet), None, None)
-            .await
-            .unwrap();
+    let exchange_client = ExchangeClient::new(
+        None,
+        wallet.clone(),
+        Some(HyperliquidChain::Testnet),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
 
     let res = exchange_client
         .enable_big_blocks(false, Some(&wallet))

--- a/src/bin/vault_transfer.rs
+++ b/src/bin/vault_transfer.rs
@@ -1,5 +1,5 @@
 use alloy::signers::local::PrivateKeySigner;
-use hyperliquid_rust_sdk::{BaseUrl, ExchangeClient};
+use hyperliquid_rust_sdk::{ExchangeClient, HyperliquidChain};
 use log::info;
 
 #[tokio::main]
@@ -11,9 +11,10 @@ async fn main() {
             .parse()
             .unwrap();
 
-    let exchange_client = ExchangeClient::new(None, wallet, Some(BaseUrl::Testnet), None, None)
-        .await
-        .unwrap();
+    let exchange_client =
+        ExchangeClient::new(None, wallet, Some(HyperliquidChain::Testnet), None, None)
+            .await
+            .unwrap();
 
     let usd = 5_000_000; // at least 5 USD
     let is_deposit = true;

--- a/src/bin/ws_active_asset_ctx.rs
+++ b/src/bin/ws_active_asset_ctx.rs
@@ -1,4 +1,4 @@
-use hyperliquid_rust_sdk::{BaseUrl, InfoClient, Message, Subscription};
+use hyperliquid_rust_sdk::{HyperliquidChain, InfoClient, Message, Subscription};
 use log::info;
 use tokio::{
     spawn,
@@ -9,7 +9,9 @@ use tokio::{
 #[tokio::main]
 async fn main() {
     env_logger::init();
-    let mut info_client = InfoClient::new(None, Some(BaseUrl::Testnet)).await.unwrap();
+    let mut info_client = InfoClient::new(None, Some(HyperliquidChain::Testnet))
+        .await
+        .unwrap();
     let coin = "BTC".to_string();
 
     let (sender, mut receiver) = unbounded_channel();

--- a/src/bin/ws_active_asset_data.rs
+++ b/src/bin/ws_active_asset_data.rs
@@ -1,5 +1,5 @@
 use alloy::primitives::address;
-use hyperliquid_rust_sdk::{BaseUrl, InfoClient, Message, Subscription};
+use hyperliquid_rust_sdk::{HyperliquidChain, InfoClient, Message, Subscription};
 use log::info;
 use tokio::{
     spawn,
@@ -10,7 +10,9 @@ use tokio::{
 #[tokio::main]
 async fn main() {
     env_logger::init();
-    let mut info_client = InfoClient::new(None, Some(BaseUrl::Testnet)).await.unwrap();
+    let mut info_client = InfoClient::new(None, Some(HyperliquidChain::Testnet))
+        .await
+        .unwrap();
     let user = address!("0xc64cc00b46101bd40aa1c3121195e85c0b0918d8");
     let coin = "BTC".to_string();
 

--- a/src/bin/ws_all_mids.rs
+++ b/src/bin/ws_all_mids.rs
@@ -1,4 +1,4 @@
-use hyperliquid_rust_sdk::{BaseUrl, InfoClient, Message, Subscription};
+use hyperliquid_rust_sdk::{HyperliquidChain, InfoClient, Message, Subscription};
 use log::info;
 use tokio::{
     spawn,
@@ -10,7 +10,9 @@ use tokio::{
 async fn main() {
     env_logger::init();
 
-    let mut info_client = InfoClient::new(None, Some(BaseUrl::Testnet)).await.unwrap();
+    let mut info_client = InfoClient::new(None, Some(HyperliquidChain::Testnet))
+        .await
+        .unwrap();
 
     let (sender, mut receiver) = unbounded_channel();
     let subscription_id = info_client

--- a/src/bin/ws_bbo.rs
+++ b/src/bin/ws_bbo.rs
@@ -1,4 +1,4 @@
-use hyperliquid_rust_sdk::{BaseUrl, InfoClient, Message, Subscription};
+use hyperliquid_rust_sdk::{HyperliquidChain, InfoClient, Message, Subscription};
 use log::info;
 use tokio::{
     spawn,
@@ -9,7 +9,9 @@ use tokio::{
 #[tokio::main]
 async fn main() {
     env_logger::init();
-    let mut info_client = InfoClient::new(None, Some(BaseUrl::Testnet)).await.unwrap();
+    let mut info_client = InfoClient::new(None, Some(HyperliquidChain::Testnet))
+        .await
+        .unwrap();
     let coin = "BTC".to_string();
 
     let (sender, mut receiver) = unbounded_channel();

--- a/src/bin/ws_candles.rs
+++ b/src/bin/ws_candles.rs
@@ -1,4 +1,4 @@
-use hyperliquid_rust_sdk::{BaseUrl, InfoClient, Message, Subscription};
+use hyperliquid_rust_sdk::{HyperliquidChain, InfoClient, Message, Subscription};
 use log::info;
 use tokio::{
     spawn,
@@ -9,7 +9,9 @@ use tokio::{
 #[tokio::main]
 async fn main() {
     env_logger::init();
-    let mut info_client = InfoClient::new(None, Some(BaseUrl::Mainnet)).await.unwrap();
+    let mut info_client = InfoClient::new(None, Some(HyperliquidChain::Mainnet))
+        .await
+        .unwrap();
 
     let (sender, mut receiver) = unbounded_channel();
     let subscription_id = info_client

--- a/src/bin/ws_l2_book.rs
+++ b/src/bin/ws_l2_book.rs
@@ -1,4 +1,4 @@
-use hyperliquid_rust_sdk::{BaseUrl, InfoClient, Message, Subscription};
+use hyperliquid_rust_sdk::{HyperliquidChain, InfoClient, Message, Subscription};
 use log::info;
 use tokio::{
     spawn,
@@ -10,7 +10,9 @@ use tokio::{
 async fn main() {
     env_logger::init();
 
-    let mut info_client = InfoClient::new(None, Some(BaseUrl::Testnet)).await.unwrap();
+    let mut info_client = InfoClient::new(None, Some(HyperliquidChain::Testnet))
+        .await
+        .unwrap();
 
     let (sender, mut receiver) = unbounded_channel();
     let subscription_id = info_client

--- a/src/bin/ws_notification.rs
+++ b/src/bin/ws_notification.rs
@@ -1,5 +1,5 @@
 use alloy::primitives::address;
-use hyperliquid_rust_sdk::{BaseUrl, InfoClient, Message, Subscription};
+use hyperliquid_rust_sdk::{HyperliquidChain, InfoClient, Message, Subscription};
 use log::info;
 use tokio::{
     spawn,
@@ -10,7 +10,9 @@ use tokio::{
 #[tokio::main]
 async fn main() {
     env_logger::init();
-    let mut info_client = InfoClient::new(None, Some(BaseUrl::Testnet)).await.unwrap();
+    let mut info_client = InfoClient::new(None, Some(HyperliquidChain::Testnet))
+        .await
+        .unwrap();
     let user = address!("0xc64cc00b46101bd40aa1c3121195e85c0b0918d8");
 
     let (sender, mut receiver) = unbounded_channel();

--- a/src/bin/ws_orders.rs
+++ b/src/bin/ws_orders.rs
@@ -1,5 +1,5 @@
 use alloy::primitives::address;
-use hyperliquid_rust_sdk::{BaseUrl, InfoClient, Message, Subscription};
+use hyperliquid_rust_sdk::{HyperliquidChain, InfoClient, Message, Subscription};
 use log::info;
 use tokio::{
     spawn,
@@ -10,7 +10,9 @@ use tokio::{
 #[tokio::main]
 async fn main() {
     env_logger::init();
-    let mut info_client = InfoClient::new(None, Some(BaseUrl::Testnet)).await.unwrap();
+    let mut info_client = InfoClient::new(None, Some(HyperliquidChain::Testnet))
+        .await
+        .unwrap();
     let user = address!("0xc64cc00b46101bd40aa1c3121195e85c0b0918d8");
 
     let (sender, mut receiver) = unbounded_channel();

--- a/src/bin/ws_spot_price.rs
+++ b/src/bin/ws_spot_price.rs
@@ -1,13 +1,15 @@
 use std::time::Duration;
 
-use hyperliquid_rust_sdk::{BaseUrl, InfoClient, Message, Subscription};
+use hyperliquid_rust_sdk::{HyperliquidChain, InfoClient, Message, Subscription};
 use log::info;
 use tokio::{spawn, sync::mpsc::unbounded_channel, time::sleep};
 
 #[tokio::main]
 async fn main() {
     env_logger::init();
-    let mut info_client = InfoClient::new(None, Some(BaseUrl::Mainnet)).await.unwrap();
+    let mut info_client = InfoClient::new(None, Some(HyperliquidChain::Mainnet))
+        .await
+        .unwrap();
 
     let (sender, mut receiver) = unbounded_channel();
     let subscription_id = info_client

--- a/src/bin/ws_trades.rs
+++ b/src/bin/ws_trades.rs
@@ -1,4 +1,4 @@
-use hyperliquid_rust_sdk::{BaseUrl, InfoClient, Message, Subscription};
+use hyperliquid_rust_sdk::{HyperliquidChain, InfoClient, Message, Subscription};
 use log::info;
 use tokio::{
     spawn,
@@ -10,7 +10,9 @@ use tokio::{
 async fn main() {
     env_logger::init();
 
-    let mut info_client = InfoClient::new(None, Some(BaseUrl::Testnet)).await.unwrap();
+    let mut info_client = InfoClient::new(None, Some(HyperliquidChain::Testnet))
+        .await
+        .unwrap();
 
     let (sender, mut receiver) = unbounded_channel();
     let subscription_id = info_client

--- a/src/bin/ws_user_events.rs
+++ b/src/bin/ws_user_events.rs
@@ -1,5 +1,5 @@
 use alloy::primitives::address;
-use hyperliquid_rust_sdk::{BaseUrl, InfoClient, Message, Subscription};
+use hyperliquid_rust_sdk::{HyperliquidChain, InfoClient, Message, Subscription};
 use log::info;
 use tokio::{
     spawn,
@@ -10,7 +10,9 @@ use tokio::{
 #[tokio::main]
 async fn main() {
     env_logger::init();
-    let mut info_client = InfoClient::new(None, Some(BaseUrl::Testnet)).await.unwrap();
+    let mut info_client = InfoClient::new(None, Some(HyperliquidChain::Testnet))
+        .await
+        .unwrap();
     let user = address!("0xc64cc00b46101bd40aa1c3121195e85c0b0918d8");
 
     let (sender, mut receiver) = unbounded_channel();

--- a/src/bin/ws_user_fundings.rs
+++ b/src/bin/ws_user_fundings.rs
@@ -1,5 +1,5 @@
 use alloy::primitives::address;
-use hyperliquid_rust_sdk::{BaseUrl, InfoClient, Message, Subscription};
+use hyperliquid_rust_sdk::{HyperliquidChain, InfoClient, Message, Subscription};
 use log::info;
 use tokio::{
     spawn,
@@ -10,7 +10,9 @@ use tokio::{
 #[tokio::main]
 async fn main() {
     env_logger::init();
-    let mut info_client = InfoClient::new(None, Some(BaseUrl::Testnet)).await.unwrap();
+    let mut info_client = InfoClient::new(None, Some(HyperliquidChain::Testnet))
+        .await
+        .unwrap();
     let user = address!("0xc64cc00b46101bd40aa1c3121195e85c0b0918d8");
 
     let (sender, mut receiver) = unbounded_channel();

--- a/src/bin/ws_user_non_funding_ledger_updates.rs
+++ b/src/bin/ws_user_non_funding_ledger_updates.rs
@@ -1,5 +1,5 @@
 use alloy::primitives::address;
-use hyperliquid_rust_sdk::{BaseUrl, InfoClient, Message, Subscription};
+use hyperliquid_rust_sdk::{HyperliquidChain, InfoClient, Message, Subscription};
 use log::info;
 use tokio::{
     spawn,
@@ -10,7 +10,9 @@ use tokio::{
 #[tokio::main]
 async fn main() {
     env_logger::init();
-    let mut info_client = InfoClient::new(None, Some(BaseUrl::Testnet)).await.unwrap();
+    let mut info_client = InfoClient::new(None, Some(HyperliquidChain::Testnet))
+        .await
+        .unwrap();
     let user = address!("0xc64cc00b46101bd40aa1c3121195e85c0b0918d8");
 
     let (sender, mut receiver) = unbounded_channel();

--- a/src/bin/ws_web_data2.rs
+++ b/src/bin/ws_web_data2.rs
@@ -1,5 +1,5 @@
 use alloy::primitives::address;
-use hyperliquid_rust_sdk::{BaseUrl, InfoClient, Message, Subscription};
+use hyperliquid_rust_sdk::{HyperliquidChain, InfoClient, Message, Subscription};
 use log::info;
 use tokio::{
     spawn,
@@ -10,7 +10,9 @@ use tokio::{
 #[tokio::main]
 async fn main() {
     env_logger::init();
-    let mut info_client = InfoClient::new(None, Some(BaseUrl::Testnet)).await.unwrap();
+    let mut info_client = InfoClient::new(None, Some(HyperliquidChain::Testnet))
+        .await
+        .unwrap();
     let user = address!("0xc64cc00b46101bd40aa1c3121195e85c0b0918d8");
 
     let (sender, mut receiver) = unbounded_channel();

--- a/src/exchange/actions.rs
+++ b/src/exchange/actions.rs
@@ -210,10 +210,6 @@ pub struct SendAsset {
     pub amount: String,
     pub from_sub_account: String,
     pub nonce: u64,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub payload_multi_sig_user: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub outer_signer: Option<String>,
 }
 
 impl Eip712 for SendAsset {
@@ -222,31 +218,7 @@ impl Eip712 for SendAsset {
     }
 
     fn struct_hash(&self) -> B256 {
-        if self.payload_multi_sig_user.is_some() && self.outer_signer.is_some() {
-            let multi_sig_user: Address = self
-                .payload_multi_sig_user
-                .as_ref()
-                .unwrap()
-                .parse()
-                .unwrap();
-            let outer_signer: Address = self.outer_signer.as_ref().unwrap().parse().unwrap();
-
-            let items = (
-                keccak256("HyperliquidTransaction:SendAsset(string hyperliquidChain,address payloadMultiSigUser,address outerSigner,string destination,string sourceDex,string destinationDex,string token,string amount,string fromSubAccount,uint64 nonce)"),
-                keccak256(&self.hyperliquid_chain),
-                multi_sig_user,
-                outer_signer,
-                keccak256(&self.destination),
-                keccak256(&self.source_dex),
-                keccak256(&self.destination_dex),
-                keccak256(&self.token),
-                keccak256(&self.amount),
-                keccak256(&self.from_sub_account),
-                &self.nonce,
-            );
-            keccak256(items.abi_encode())
-        } else {
-            let items = (
+        let items = (
                 keccak256("HyperliquidTransaction:SendAsset(string hyperliquidChain,string destination,string sourceDex,string destinationDex,string token,string amount,string fromSubAccount,uint64 nonce)"),
                 keccak256(&self.hyperliquid_chain),
                 keccak256(&self.destination),
@@ -257,8 +229,7 @@ impl Eip712 for SendAsset {
                 keccak256(&self.from_sub_account),
                 &self.nonce,
             );
-            keccak256(items.abi_encode())
-        }
+        keccak256(items.abi_encode())
     }
 }
 

--- a/src/exchange/actions.rs
+++ b/src/exchange/actions.rs
@@ -223,9 +223,14 @@ impl Eip712 for SendAsset {
 
     fn struct_hash(&self) -> B256 {
         if self.payload_multi_sig_user.is_some() && self.outer_signer.is_some() {
-            let multi_sig_user: Address = self.payload_multi_sig_user.as_ref().unwrap().parse().unwrap();
+            let multi_sig_user: Address = self
+                .payload_multi_sig_user
+                .as_ref()
+                .unwrap()
+                .parse()
+                .unwrap();
             let outer_signer: Address = self.outer_signer.as_ref().unwrap().parse().unwrap();
-            
+
             let items = (
                 keccak256("HyperliquidTransaction:SendAsset(string hyperliquidChain,address payloadMultiSigUser,address outerSigner,string destination,string sourceDex,string destinationDex,string token,string amount,string fromSubAccount,uint64 nonce)"),
                 keccak256(&self.hyperliquid_chain),

--- a/src/exchange/actions.rs
+++ b/src/exchange/actions.rs
@@ -210,6 +210,10 @@ pub struct SendAsset {
     pub amount: String,
     pub from_sub_account: String,
     pub nonce: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub payload_multi_sig_user: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub outer_signer: Option<String>,
 }
 
 impl Eip712 for SendAsset {
@@ -218,7 +222,31 @@ impl Eip712 for SendAsset {
     }
 
     fn struct_hash(&self) -> B256 {
-        let items = (
+        if self.payload_multi_sig_user.is_some() && self.outer_signer.is_some() {
+            let multi_sig_user: Address = self
+                .payload_multi_sig_user
+                .as_ref()
+                .unwrap()
+                .parse()
+                .unwrap();
+            let outer_signer: Address = self.outer_signer.as_ref().unwrap().parse().unwrap();
+
+            let items = (
+                keccak256("HyperliquidTransaction:SendAsset(string hyperliquidChain,address payloadMultiSigUser,address outerSigner,string destination,string sourceDex,string destinationDex,string token,string amount,string fromSubAccount,uint64 nonce)"),
+                keccak256(&self.hyperliquid_chain),
+                multi_sig_user,
+                outer_signer,
+                keccak256(&self.destination),
+                keccak256(&self.source_dex),
+                keccak256(&self.destination_dex),
+                keccak256(&self.token),
+                keccak256(&self.amount),
+                keccak256(&self.from_sub_account),
+                &self.nonce,
+            );
+            keccak256(items.abi_encode())
+        } else {
+            let items = (
                 keccak256("HyperliquidTransaction:SendAsset(string hyperliquidChain,string destination,string sourceDex,string destinationDex,string token,string amount,string fromSubAccount,uint64 nonce)"),
                 keccak256(&self.hyperliquid_chain),
                 keccak256(&self.destination),
@@ -229,7 +257,8 @@ impl Eip712 for SendAsset {
                 keccak256(&self.from_sub_account),
                 &self.nonce,
             );
-        keccak256(items.abi_encode())
+            keccak256(items.abi_encode())
+        }
     }
 }
 

--- a/src/exchange/actions.rs
+++ b/src/exchange/actions.rs
@@ -293,15 +293,43 @@ impl Eip712 for SpotSend {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
-pub struct SpotUser {
-    pub class_transfer: ClassTransfer,
+pub struct UsdClassTransfer {
+    #[serde(serialize_with = "serialize_hex", deserialize_with = "deserialize_hex")]
+    pub signature_chain_id: u64,
+    pub hyperliquid_chain: String,
+    pub amount: String,
+    pub to_perp: bool,
+    pub nonce: u64,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(rename_all = "camelCase")]
-pub struct ClassTransfer {
-    pub usdc: u64,
-    pub to_perp: bool,
+impl UsdClassTransfer {
+    pub fn new(hyperliquid_chain: HyperliquidChain, amount: String, to_perp: bool) -> Self {
+        let signature_chain_id = default_signature_chain_id(&hyperliquid_chain, None);
+        Self {
+            signature_chain_id,
+            hyperliquid_chain: hyperliquid_chain.action_chain_name(),
+            amount,
+            to_perp,
+            nonce: next_nonce(),
+        }
+    }
+}
+
+impl Eip712 for UsdClassTransfer {
+    fn domain(&self) -> Eip712Domain {
+        eip_712_domain(self.signature_chain_id)
+    }
+
+    fn struct_hash(&self) -> B256 {
+        let items = (
+            keccak256("HyperliquidTransaction:UsdClassTransfer(string hyperliquidChain,string amount,bool toPerp,uint64 nonce)"),
+            keccak256(&self.hyperliquid_chain),
+            keccak256(&self.amount),
+            self.to_perp,
+            self.nonce,
+        );
+        keccak256(items.abi_encode())
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]

--- a/src/exchange/actions.rs
+++ b/src/exchange/actions.rs
@@ -439,6 +439,27 @@ pub struct CreateSubAccount {
     pub name: String,
 }
 
+/// Moves perp USD between a master account and one of its sub-accounts.
+/// `usd` is an integer amount of USD scaled by 1e6.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct SubAccountTransfer {
+    pub sub_account_user: String,
+    pub is_deposit: bool,
+    pub usd: u64,
+}
+
+/// Moves a spot token between a master account and one of its sub-accounts.
+/// `token` is the `NAME:tokenId` pair and `amount` a decimal string.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct SubAccountSpotTransfer {
+    pub sub_account_user: String,
+    pub is_deposit: bool,
+    pub token: String,
+    pub amount: String,
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct EvmUserModify {

--- a/src/exchange/actions.rs
+++ b/src/exchange/actions.rs
@@ -6,9 +6,11 @@ use alloy::{
 use serde::{Deserialize, Serialize, Serializer};
 
 use super::{cancel::CancelRequestCloid, BuilderInfo};
+use crate::helpers::next_nonce;
 use crate::{
     eip712::Eip712,
     exchange::{cancel::CancelRequest, modify::ModifyRequest, order::OrderRequest},
+    HyperliquidChain,
 };
 
 fn eip_712_domain(chain_id: u64) -> Eip712Domain {
@@ -27,13 +29,29 @@ where
     s.serialize_str(&format!("0x{val:x}"))
 }
 
-#[derive(Debug, Clone, Deserialize)]
+fn default_signature_chain_id(
+    hyperliquid_chain: &HyperliquidChain,
+    signature_chain_id: Option<u64>,
+) -> u64 {
+    match signature_chain_id {
+        Some(signature_chain_id) => signature_chain_id,
+        None => {
+            if hyperliquid_chain.is_mainnet() {
+                42161 // Arbitrum One
+            } else {
+                421614 // Arbitrum Sepolia
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq)]
 pub struct MultiSigExtension {
     pub payload_multi_sig_user: String,
     pub outer_signer: String,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct UsdSend {
     #[serde(serialize_with = "serialize_hex")]
@@ -42,6 +60,24 @@ pub struct UsdSend {
     pub destination: String,
     pub amount: String,
     pub time: u64,
+}
+
+impl UsdSend {
+    pub fn new(
+        hyperliquid_chain: HyperliquidChain,
+        destination: String,
+        amount: String,
+        signature_chain_id: Option<u64>,
+    ) -> Self {
+        let signature_chain_id = default_signature_chain_id(&hyperliquid_chain, signature_chain_id);
+        Self {
+            signature_chain_id,
+            hyperliquid_chain: hyperliquid_chain.action_chain_name(),
+            destination,
+            amount,
+            time: next_nonce(),
+        }
+    }
 }
 
 impl Eip712 for UsdSend {
@@ -115,6 +151,24 @@ pub struct ApproveAgent {
     pub nonce: u64,
 }
 
+impl ApproveAgent {
+    pub fn new(
+        hyperliquid_chain: HyperliquidChain,
+        agent_address: Address,
+        agent_name: Option<String>,
+        signature_chain_id: Option<u64>,
+    ) -> Self {
+        let signature_chain_id = default_signature_chain_id(&hyperliquid_chain, signature_chain_id);
+        Self {
+            signature_chain_id,
+            hyperliquid_chain: hyperliquid_chain.action_chain_name(),
+            agent_address,
+            agent_name,
+            nonce: next_nonce(),
+        }
+    }
+}
+
 impl Eip712 for ApproveAgent {
     fn domain(&self) -> Eip712Domain {
         eip_712_domain(self.signature_chain_id)
@@ -132,7 +186,7 @@ impl Eip712 for ApproveAgent {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct Withdraw3 {
     #[serde(serialize_with = "serialize_hex")]
@@ -141,6 +195,24 @@ pub struct Withdraw3 {
     pub destination: String,
     pub amount: String,
     pub time: u64,
+}
+
+impl Withdraw3 {
+    pub fn new(
+        hyperliquid_chain: HyperliquidChain,
+        destination: String,
+        amount: String,
+        signature_chain_id: Option<u64>,
+    ) -> Self {
+        let signature_chain_id = default_signature_chain_id(&hyperliquid_chain, signature_chain_id);
+        Self {
+            signature_chain_id,
+            hyperliquid_chain: hyperliquid_chain.action_chain_name(),
+            destination,
+            amount,
+            time: next_nonce(),
+        }
+    }
 }
 
 impl Eip712 for Withdraw3 {
@@ -170,6 +242,26 @@ pub struct SpotSend {
     pub token: String,
     pub amount: String,
     pub time: u64,
+}
+
+impl SpotSend {
+    pub fn new(
+        hyperliquid_chain: HyperliquidChain,
+        destination: String,
+        token: String,
+        amount: String,
+        signature_chain_id: Option<u64>,
+    ) -> Self {
+        let signature_chain_id = default_signature_chain_id(&hyperliquid_chain, signature_chain_id);
+        Self {
+            signature_chain_id,
+            hyperliquid_chain: hyperliquid_chain.action_chain_name(),
+            destination,
+            token,
+            amount,
+            time: next_nonce(),
+        }
+    }
 }
 
 impl Eip712 for SpotSend {
@@ -203,7 +295,7 @@ pub struct ClassTransfer {
     pub to_perp: bool,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct SendAsset {
     #[serde(serialize_with = "serialize_hex")]
@@ -218,6 +310,35 @@ pub struct SendAsset {
     pub nonce: u64,
     #[serde(skip)]
     pub multi_sig_ext: Option<MultiSigExtension>,
+}
+
+impl SendAsset {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        hyperliquid_chain: HyperliquidChain,
+        destination: String,
+        source_dex: String,
+        destination_dex: String,
+        token: String,
+        amount: String,
+        from_sub_account: String,
+        multi_sig_ext: Option<MultiSigExtension>,
+        signature_chain_id: Option<u64>,
+    ) -> Self {
+        let signature_chain_id = default_signature_chain_id(&hyperliquid_chain, signature_chain_id);
+        Self {
+            signature_chain_id,
+            hyperliquid_chain: hyperliquid_chain.action_chain_name(),
+            destination,
+            source_dex,
+            destination_dex,
+            token,
+            amount,
+            from_sub_account,
+            nonce: next_nonce(),
+            multi_sig_ext,
+        }
+    }
 }
 
 impl Eip712 for SendAsset {
@@ -281,7 +402,7 @@ pub struct EvmUserModify {
     pub using_big_blocks: bool,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct ApproveBuilderFee {
     #[serde(serialize_with = "serialize_hex")]
@@ -290,6 +411,24 @@ pub struct ApproveBuilderFee {
     pub builder: Address,
     pub max_fee_rate: String,
     pub nonce: u64,
+}
+
+impl ApproveBuilderFee {
+    pub fn new(
+        hyperliquid_chain: HyperliquidChain,
+        builder: Address,
+        max_fee_rate: String,
+        signature_chain_id: Option<u64>,
+    ) -> Self {
+        let signature_chain_id = default_signature_chain_id(&hyperliquid_chain, signature_chain_id);
+        Self {
+            signature_chain_id,
+            hyperliquid_chain: hyperliquid_chain.action_chain_name(),
+            builder,
+            max_fee_rate,
+            nonce: next_nonce(),
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -323,7 +462,7 @@ impl Eip712 for ApproveBuilderFee {
 // Multi-sig related structs
 
 /// Convert a regular user account to a multi-sig account
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct ConvertToMultiSig {
     #[serde(serialize_with = "serialize_hex")]
@@ -331,6 +470,22 @@ pub struct ConvertToMultiSig {
     pub hyperliquid_chain: String,
     pub multi_sig_threshold: u64,
     pub time: u64,
+}
+
+impl ConvertToMultiSig {
+    pub fn new(
+        hyperliquid_chain: HyperliquidChain,
+        multi_sig_threshold: u64,
+        signature_chain_id: Option<u64>,
+    ) -> Self {
+        let signature_chain_id = default_signature_chain_id(&hyperliquid_chain, signature_chain_id);
+        Self {
+            signature_chain_id,
+            hyperliquid_chain: hyperliquid_chain.action_chain_name(),
+            multi_sig_threshold,
+            time: next_nonce(),
+        }
+    }
 }
 
 impl Eip712 for ConvertToMultiSig {
@@ -349,7 +504,7 @@ impl Eip712 for ConvertToMultiSig {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct UpdateMultiSigAddresses {
     #[serde(serialize_with = "serialize_hex")]
@@ -358,6 +513,24 @@ pub struct UpdateMultiSigAddresses {
     pub to_add: Vec<Address>,
     pub to_remove: Vec<Address>,
     pub time: u64,
+}
+
+impl UpdateMultiSigAddresses {
+    pub fn new(
+        hyperliquid_chain: HyperliquidChain,
+        to_add: Vec<Address>,
+        to_remove: Vec<Address>,
+        signature_chain_id: Option<u64>,
+    ) -> Self {
+        let signature_chain_id = default_signature_chain_id(&hyperliquid_chain, signature_chain_id);
+        Self {
+            signature_chain_id,
+            hyperliquid_chain: hyperliquid_chain.action_chain_name(),
+            to_add,
+            to_remove,
+            time: next_nonce(),
+        }
+    }
 }
 
 impl Eip712 for UpdateMultiSigAddresses {
@@ -407,5 +580,161 @@ impl Eip712 for MultiSigEnvelope {
             &self.nonce,
         );
         keccak256(items.abi_encode())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::prelude::Result;
+    use crate::HyperliquidChain;
+    use alloy::primitives::address;
+
+    #[test]
+    fn test_usd_send_new_helper() -> Result<()> {
+        let with_helper = UsdSend::new(
+            HyperliquidChain::Testnet,
+            "0x0D1d9635D0640821d15e323ac8AdADfA9c111414".to_string(),
+            "1".to_string(),
+            None,
+        );
+        let time = with_helper.time;
+
+        let manual = UsdSend {
+            signature_chain_id: 421614,
+            hyperliquid_chain: "Testnet".to_string(),
+            destination: "0x0D1d9635D0640821d15e323ac8AdADfA9c111414".to_string(),
+            amount: "1".to_string(),
+            time,
+        };
+
+        assert_eq!(manual, with_helper);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_withdraw3_new_helper() -> Result<()> {
+        let with_helper = Withdraw3::new(
+            HyperliquidChain::Testnet,
+            "0x0D1d9635D0640821d15e323ac8AdADfA9c111414".to_string(),
+            "1".to_string(),
+            None,
+        );
+        let time = with_helper.time;
+
+        let manual = Withdraw3 {
+            signature_chain_id: 421614,
+            hyperliquid_chain: "Testnet".to_string(),
+            destination: "0x0D1d9635D0640821d15e323ac8AdADfA9c111414".to_string(),
+            amount: "1".to_string(),
+            time,
+        };
+
+        assert_eq!(manual, with_helper);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_approve_builder_fee_new_helper() -> Result<()> {
+        let with_helper = ApproveBuilderFee::new(
+            HyperliquidChain::Testnet,
+            address!("0x1234567890123456789012345678901234567890"),
+            "0.001%".to_string(),
+            None,
+        );
+        let nonce = with_helper.nonce;
+
+        let manual = ApproveBuilderFee {
+            signature_chain_id: 421614,
+            hyperliquid_chain: "Testnet".to_string(),
+            builder: address!("0x1234567890123456789012345678901234567890"),
+            max_fee_rate: "0.001%".to_string(),
+            nonce,
+        };
+
+        assert_eq!(manual, with_helper);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_send_asset_new_helper() -> Result<()> {
+        let with_helper = SendAsset::new(
+            HyperliquidChain::Testnet,
+            "0x1234567890123456789012345678901234567890".to_string(),
+            "spot".to_string(),
+            "".to_string(),
+            "USDC".to_string(),
+            "50".to_string(),
+            "".to_string(),
+            None,
+            None,
+        );
+        let nonce = with_helper.nonce;
+
+        let manual = SendAsset {
+            signature_chain_id: 421614,
+            hyperliquid_chain: "Testnet".to_string(),
+            destination: "0x1234567890123456789012345678901234567890".to_string(),
+            source_dex: "spot".to_string(),
+            destination_dex: "".to_string(),
+            token: "USDC".to_string(),
+            amount: "50".to_string(),
+            from_sub_account: "".to_string(),
+            nonce,
+            multi_sig_ext: None,
+        };
+
+        assert_eq!(manual, with_helper);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_convert_to_multi_sig_new_helper() -> Result<()> {
+        let with_helper = ConvertToMultiSig::new(HyperliquidChain::Testnet, 1, None);
+        let time = with_helper.time;
+
+        let manual = ConvertToMultiSig {
+            signature_chain_id: 421614,
+            hyperliquid_chain: "Testnet".to_string(),
+            multi_sig_threshold: 1,
+            time,
+        };
+
+        assert_eq!(manual, with_helper);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_update_multi_sig_addresses_new_helper() -> Result<()> {
+        let with_helper = UpdateMultiSigAddresses::new(
+            HyperliquidChain::Testnet,
+            vec![
+                address!("0x0D1d9635D0640821d15e323ac8AdADfA9c111414"),
+                address!("0x1234567890123456789012345678901234567890"),
+            ],
+            vec![address!("0xabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd")],
+            None,
+        );
+        let time = with_helper.time;
+
+        let manual = UpdateMultiSigAddresses {
+            signature_chain_id: 421614,
+            hyperliquid_chain: "Testnet".to_string(),
+            to_add: vec![
+                address!("0x0D1d9635D0640821d15e323ac8AdADfA9c111414"),
+                address!("0x1234567890123456789012345678901234567890"),
+            ],
+            to_remove: vec![address!("0xabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd")],
+            time,
+        };
+
+        assert_eq!(manual, with_helper);
+
+        Ok(())
     }
 }

--- a/src/exchange/actions.rs
+++ b/src/exchange/actions.rs
@@ -435,6 +435,12 @@ pub struct SetReferrer {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
+pub struct CreateSubAccount {
+    pub name: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct EvmUserModify {
     pub using_big_blocks: bool,
 }

--- a/src/exchange/actions.rs
+++ b/src/exchange/actions.rs
@@ -3,7 +3,7 @@ use alloy::{
     primitives::{keccak256, Address, B256},
     sol_types::{eip712_domain, SolValue},
 };
-use serde::{Deserialize, Serialize, Serializer};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use super::{cancel::CancelRequestCloid, BuilderInfo};
 use crate::helpers::next_nonce;
@@ -27,6 +27,15 @@ where
     S: Serializer,
 {
     s.serialize_str(&format!("0x{val:x}"))
+}
+
+fn deserialize_hex<'de, D>(d: D) -> Result<u64, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let s = String::deserialize(d)?;
+    let s = s.strip_prefix("0x").unwrap_or(&s);
+    u64::from_str_radix(s, 16).map_err(serde::de::Error::custom)
 }
 
 fn default_signature_chain_id(
@@ -54,7 +63,7 @@ pub struct MultiSigExtension {
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct UsdSend {
-    #[serde(serialize_with = "serialize_hex")]
+    #[serde(serialize_with = "serialize_hex", deserialize_with = "deserialize_hex")]
     pub signature_chain_id: u64,
     pub hyperliquid_chain: String,
     pub destination: String,
@@ -143,7 +152,7 @@ pub struct BulkCancelCloid {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ApproveAgent {
-    #[serde(serialize_with = "serialize_hex")]
+    #[serde(serialize_with = "serialize_hex", deserialize_with = "deserialize_hex")]
     pub signature_chain_id: u64,
     pub hyperliquid_chain: String,
     pub agent_address: Address,
@@ -189,7 +198,7 @@ impl Eip712 for ApproveAgent {
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct Withdraw3 {
-    #[serde(serialize_with = "serialize_hex")]
+    #[serde(serialize_with = "serialize_hex", deserialize_with = "deserialize_hex")]
     pub signature_chain_id: u64,
     pub hyperliquid_chain: String,
     pub destination: String,
@@ -235,7 +244,7 @@ impl Eip712 for Withdraw3 {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct SpotSend {
-    #[serde(serialize_with = "serialize_hex")]
+    #[serde(serialize_with = "serialize_hex", deserialize_with = "deserialize_hex")]
     pub signature_chain_id: u64,
     pub hyperliquid_chain: String,
     pub destination: String,
@@ -298,7 +307,7 @@ pub struct ClassTransfer {
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct SendAsset {
-    #[serde(serialize_with = "serialize_hex")]
+    #[serde(serialize_with = "serialize_hex", deserialize_with = "deserialize_hex")]
     pub signature_chain_id: u64,
     pub hyperliquid_chain: String,
     pub destination: String,
@@ -405,7 +414,7 @@ pub struct EvmUserModify {
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct ApproveBuilderFee {
-    #[serde(serialize_with = "serialize_hex")]
+    #[serde(serialize_with = "serialize_hex", deserialize_with = "deserialize_hex")]
     pub signature_chain_id: u64,
     pub hyperliquid_chain: String,
     pub builder: Address,
@@ -465,7 +474,7 @@ impl Eip712 for ApproveBuilderFee {
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct ConvertToMultiSig {
-    #[serde(serialize_with = "serialize_hex")]
+    #[serde(serialize_with = "serialize_hex", deserialize_with = "deserialize_hex")]
     pub signature_chain_id: u64,
     pub hyperliquid_chain: String,
     pub multi_sig_threshold: u64,
@@ -507,7 +516,7 @@ impl Eip712 for ConvertToMultiSig {
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct UpdateMultiSigAddresses {
-    #[serde(serialize_with = "serialize_hex")]
+    #[serde(serialize_with = "serialize_hex", deserialize_with = "deserialize_hex")]
     pub signature_chain_id: u64,
     pub hyperliquid_chain: String,
     pub to_add: Vec<Address>,
@@ -560,7 +569,7 @@ impl Eip712 for UpdateMultiSigAddresses {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct MultiSigEnvelope {
-    #[serde(serialize_with = "serialize_hex")]
+    #[serde(serialize_with = "serialize_hex", deserialize_with = "deserialize_hex")]
     pub signature_chain_id: u64,
     pub hyperliquid_chain: String,
     pub multi_sig_action_hash: B256,

--- a/src/exchange/exchange_client.rs
+++ b/src/exchange/exchange_client.rs
@@ -300,7 +300,7 @@ impl ExchangeClient {
         let usd_send = UsdSend {
             signature_chain_id: 421614,
             hyperliquid_chain,
-            destination: destination.to_string(),
+            destination: destination.to_lowercase(),
             amount: amount.to_string(),
             time: timestamp,
         };
@@ -361,7 +361,7 @@ impl ExchangeClient {
         let send_asset = SendAsset {
             signature_chain_id: 421614,
             hyperliquid_chain,
-            destination: destination.to_string(),
+            destination: destination.to_lowercase(),
             source_dex: source_dex.to_string(),
             destination_dex: destination_dex.to_string(),
             token: token.to_string(),
@@ -843,7 +843,7 @@ impl ExchangeClient {
         let withdraw = Withdraw3 {
             signature_chain_id: 421614,
             hyperliquid_chain,
-            destination: destination.to_string(),
+            destination: destination.to_lowercase(),
             amount: amount.to_string(),
             time: timestamp,
         };
@@ -872,7 +872,7 @@ impl ExchangeClient {
         let spot_send = SpotSend {
             signature_chain_id: 421614,
             hyperliquid_chain,
-            destination: destination.to_string(),
+            destination: destination.to_lowercase(),
             amount: amount.to_string(),
             time: timestamp,
             token: token.to_string(),
@@ -1198,7 +1198,7 @@ impl ExchangeClient {
         let send_asset = SendAsset {
             signature_chain_id: 421614,
             hyperliquid_chain,
-            destination: destination.to_string(),
+            destination: destination.to_lowercase(),
             source_dex: "".to_string(),
             destination_dex: "".to_string(),
             token: "USDC".to_string(),
@@ -1243,7 +1243,7 @@ impl ExchangeClient {
         let send_asset = SendAsset {
             signature_chain_id: 421614,
             hyperliquid_chain,
-            destination: destination.to_string(),
+            destination: destination.to_lowercase(),
             source_dex: "".to_string(),
             destination_dex: "".to_string(),
             token: token.to_string(),
@@ -1338,7 +1338,7 @@ impl ExchangeClient {
         let send_asset = SendAsset {
             signature_chain_id: 421614,
             hyperliquid_chain,
-            destination: destination.to_string(),
+            destination: destination.to_lowercase(),
             source_dex: "".to_string(),
             destination_dex: "".to_string(),
             token: "USDC".to_string(),
@@ -1391,7 +1391,7 @@ impl ExchangeClient {
         let send_asset = SendAsset {
             signature_chain_id: 421614,
             hyperliquid_chain,
-            destination: destination.to_string(),
+            destination: destination.to_lowercase(),
             source_dex: "".to_string(),
             destination_dex: "".to_string(),
             token: token.to_string(),

--- a/src/exchange/exchange_client.rs
+++ b/src/exchange/exchange_client.rs
@@ -23,6 +23,7 @@ use crate::{
     SpotSend, SpotUser, VaultTransfer, Withdraw3,
 };
 use alloy::{
+    hex,
     primitives::{keccak256, Address, Signature, B256},
     signers::local::PrivateKeySigner,
 };
@@ -93,8 +94,8 @@ where
     let mut seq = s.serialize_seq(Some(sigs.len()))?;
     for sig in sigs {
         let sig_obj = SignatureObj {
-            r: sig.r(),
-            s: sig.s(),
+            r: format!("0x{}", hex::encode::<[u8; 32]>(sig.r().to_be_bytes())),
+            s: format!("0x{}", hex::encode::<[u8; 32]>(sig.s().to_be_bytes())),
             v: 27 + sig.v() as u64,
         };
         seq.serialize_element(&sig_obj)?;
@@ -104,8 +105,8 @@ where
 
 #[derive(Serialize)]
 struct SignatureObj {
-    r: alloy::primitives::U256,
-    s: alloy::primitives::U256,
+    r: String,
+    s: String,
     v: u64,
 }
 

--- a/src/exchange/exchange_client.rs
+++ b/src/exchange/exchange_client.rs
@@ -1194,7 +1194,7 @@ impl ExchangeClient {
             "Testnet".to_string()
         };
 
-        let timestamp = 1111111;
+        let timestamp = next_nonce();
 
         let send_asset = SendAsset {
             signature_chain_id: 421614,

--- a/src/exchange/exchange_client.rs
+++ b/src/exchange/exchange_client.rs
@@ -1194,7 +1194,7 @@ impl ExchangeClient {
             "Testnet".to_string()
         };
 
-        let timestamp = next_nonce();
+        let timestamp = 1111111;
 
         let send_asset = SendAsset {
             signature_chain_id: 421614,

--- a/src/exchange/exchange_client.rs
+++ b/src/exchange/exchange_client.rs
@@ -368,6 +368,8 @@ impl ExchangeClient {
             amount: amount.to_string(),
             from_sub_account,
             nonce: timestamp,
+            payload_multi_sig_user: None,
+            outer_signer: None,
         };
 
         let signature = sign_typed_data(&send_asset, wallet)?;
@@ -1204,6 +1206,8 @@ impl ExchangeClient {
             amount: amount.to_string(),
             from_sub_account: "".to_string(),
             nonce: timestamp,
+            payload_multi_sig_user: Some(format!("{:#x}", multi_sig_user).to_lowercase()),
+            outer_signer: Some(format!("{:#x}", self.wallet.address()).to_lowercase()),
         };
 
         let signatures = sign_typed_data_multi_sig(&send_asset, wallets)?;
@@ -1245,6 +1249,8 @@ impl ExchangeClient {
             amount: amount.to_string(),
             from_sub_account: "".to_string(),
             nonce: timestamp,
+            payload_multi_sig_user: Some(format!("{:#x}", multi_sig_user).to_lowercase()),
+            outer_signer: Some(format!("{:#x}", self.wallet.address()).to_lowercase()),
         };
 
         let signatures = sign_typed_data_multi_sig(&send_asset, wallets)?;
@@ -1293,6 +1299,8 @@ impl ExchangeClient {
     ///     amount: "100".to_string(),
     ///     from_sub_account: "".to_string(),
     ///     nonce: 123456789,
+    ///     payload_multi_sig_user: Some(format!("{:#x}", multi_sig_user).to_lowercase()),
+    ///     outer_signer: Some("0x...".to_lowercase()),
     /// };
     ///
     /// let sig1 = sign_multi_sig_user_signed_action_single(&wallet1, &send_asset)?;
@@ -1332,6 +1340,8 @@ impl ExchangeClient {
             amount: amount.to_string(),
             from_sub_account: "".to_string(),
             nonce: timestamp,
+            payload_multi_sig_user: Some(format!("{:#x}", multi_sig_user).to_lowercase()),
+            outer_signer: Some(format!("{:#x}", self.wallet.address()).to_lowercase()),
         };
 
         let mut action =
@@ -1381,6 +1391,8 @@ impl ExchangeClient {
             amount: amount.to_string(),
             from_sub_account: "".to_string(),
             nonce: timestamp,
+            payload_multi_sig_user: Some(format!("{:#x}", multi_sig_user).to_lowercase()),
+            outer_signer: Some(format!("{:#x}", self.wallet.address()).to_lowercase()),
         };
 
         let mut action =
@@ -1647,6 +1659,8 @@ mod tests {
             amount: "100".to_string(),
             from_sub_account: "".to_string(),
             nonce: 1583838,
+            payload_multi_sig_user: None,
+            outer_signer: None,
         };
 
         let mainnet_signature = sign_typed_data(&mainnet_send, &wallet)?;
@@ -1661,6 +1675,8 @@ mod tests {
             amount: "50".to_string(),
             from_sub_account: "".to_string(),
             nonce: 1583838,
+            payload_multi_sig_user: None,
+            outer_signer: None,
         };
 
         let testnet_signature = sign_typed_data(&testnet_send, &wallet)?;
@@ -1676,6 +1692,8 @@ mod tests {
             amount: "100".to_string(),
             from_sub_account: "0xabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd".to_string(),
             nonce: 1583838,
+            payload_multi_sig_user: None,
+            outer_signer: None,
         };
 
         let vault_signature = sign_typed_data(&vault_send, &wallet)?;

--- a/src/exchange/exchange_client.rs
+++ b/src/exchange/exchange_client.rs
@@ -368,8 +368,6 @@ impl ExchangeClient {
             amount: amount.to_string(),
             from_sub_account,
             nonce: timestamp,
-            payload_multi_sig_user: None,
-            outer_signer: None,
         };
 
         let signature = sign_typed_data(&send_asset, wallet)?;
@@ -1206,8 +1204,6 @@ impl ExchangeClient {
             amount: amount.to_string(),
             from_sub_account: "".to_string(),
             nonce: timestamp,
-            payload_multi_sig_user: Some(format!("{:#x}", multi_sig_user).to_lowercase()),
-            outer_signer: Some(format!("{:#x}", self.wallet.address()).to_lowercase()),
         };
 
         let signatures = sign_typed_data_multi_sig(&send_asset, wallets)?;
@@ -1249,8 +1245,6 @@ impl ExchangeClient {
             amount: amount.to_string(),
             from_sub_account: "".to_string(),
             nonce: timestamp,
-            payload_multi_sig_user: Some(format!("{:#x}", multi_sig_user).to_lowercase()),
-            outer_signer: Some(format!("{:#x}", self.wallet.address()).to_lowercase()),
         };
 
         let signatures = sign_typed_data_multi_sig(&send_asset, wallets)?;
@@ -1299,8 +1293,6 @@ impl ExchangeClient {
     ///     amount: "100".to_string(),
     ///     from_sub_account: "".to_string(),
     ///     nonce: 123456789,
-    ///     payload_multi_sig_user: Some(format!("{:#x}", multi_sig_user).to_lowercase()),
-    ///     outer_signer: Some("0x...".to_lowercase()),
     /// };
     ///
     /// let sig1 = sign_multi_sig_user_signed_action_single(&wallet1, &send_asset)?;
@@ -1340,8 +1332,6 @@ impl ExchangeClient {
             amount: amount.to_string(),
             from_sub_account: "".to_string(),
             nonce: timestamp,
-            payload_multi_sig_user: Some(format!("{:#x}", multi_sig_user).to_lowercase()),
-            outer_signer: Some(format!("{:#x}", self.wallet.address()).to_lowercase()),
         };
 
         let mut action =
@@ -1391,8 +1381,6 @@ impl ExchangeClient {
             amount: amount.to_string(),
             from_sub_account: "".to_string(),
             nonce: timestamp,
-            payload_multi_sig_user: Some(format!("{:#x}", multi_sig_user).to_lowercase()),
-            outer_signer: Some(format!("{:#x}", self.wallet.address()).to_lowercase()),
         };
 
         let mut action =
@@ -1659,8 +1647,6 @@ mod tests {
             amount: "100".to_string(),
             from_sub_account: "".to_string(),
             nonce: 1583838,
-            payload_multi_sig_user: None,
-            outer_signer: None,
         };
 
         let mainnet_signature = sign_typed_data(&mainnet_send, &wallet)?;
@@ -1675,8 +1661,6 @@ mod tests {
             amount: "50".to_string(),
             from_sub_account: "".to_string(),
             nonce: 1583838,
-            payload_multi_sig_user: None,
-            outer_signer: None,
         };
 
         let testnet_signature = sign_typed_data(&testnet_send, &wallet)?;
@@ -1692,8 +1676,6 @@ mod tests {
             amount: "100".to_string(),
             from_sub_account: "0xabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd".to_string(),
             nonce: 1583838,
-            payload_multi_sig_user: None,
-            outer_signer: None,
         };
 
         let vault_signature = sign_typed_data(&vault_send, &wallet)?;

--- a/src/exchange/exchange_client.rs
+++ b/src/exchange/exchange_client.rs
@@ -1185,7 +1185,7 @@ impl ExchangeClient {
             "Testnet".to_string()
         };
 
-        let timestamp = 1762838147000;
+        let timestamp = next_nonce();
 
         let send_asset = SendAsset {
             signature_chain_id: 421614,

--- a/src/exchange/exchange_client.rs
+++ b/src/exchange/exchange_client.rs
@@ -976,7 +976,7 @@ impl ExchangeClient {
     ) -> Result<ExchangeResponseStatus> {
         let multi_sig_action = MultiSigAction {
             type_: "multiSig".to_string(),
-            signature_chain_id: "0x1".to_string(),
+            signature_chain_id: "0x66eee".to_string(),
             signatures: inner_signatures,
             payload: MultiSigPayload {
                 multi_sig_user: multi_sig_user.to_string().to_lowercase(),

--- a/src/exchange/exchange_client.rs
+++ b/src/exchange/exchange_client.rs
@@ -976,7 +976,7 @@ impl ExchangeClient {
     ) -> Result<ExchangeResponseStatus> {
         let multi_sig_action = MultiSigAction {
             type_: "multiSig".to_string(),
-            signature_chain_id: "0x66eee".to_string(),
+            signature_chain_id: "0x1".to_string(),
             signatures: inner_signatures,
             payload: MultiSigPayload {
                 multi_sig_user: multi_sig_user.to_string().to_lowercase(),

--- a/src/exchange/exchange_client.rs
+++ b/src/exchange/exchange_client.rs
@@ -1186,7 +1186,7 @@ impl ExchangeClient {
             "Testnet".to_string()
         };
 
-        let timestamp = 1762838147000;
+        let timestamp = next_nonce();
 
         let send_asset = SendAsset {
             signature_chain_id: 421614,

--- a/src/exchange/exchange_client.rs
+++ b/src/exchange/exchange_client.rs
@@ -29,8 +29,8 @@ use crate::{
         sign_l1_action, sign_multi_sig_action, sign_multi_sig_l1_action_payload, sign_typed_data,
         sign_typed_data_multi_sig,
     },
-    BaseUrl, BulkCancelCloid, ClassTransfer, Error, ExchangeResponseStatus, SpotSend, SpotUser,
-    VaultTransfer, Withdraw3,
+    BaseUrl, BulkCancelCloid, ClassTransfer, Error, ExchangeResponseStatus, MultiSigExtension,
+    SpotSend, SpotUser, VaultTransfer, Withdraw3,
 };
 
 #[derive(Debug)]
@@ -368,8 +368,7 @@ impl ExchangeClient {
             amount: amount.to_string(),
             from_sub_account,
             nonce: timestamp,
-            payload_multi_sig_user: None,
-            outer_signer: None,
+            multi_sig_ext: None,
         };
 
         let signature = sign_typed_data(&send_asset, wallet)?;
@@ -1206,8 +1205,10 @@ impl ExchangeClient {
             amount: amount.to_string(),
             from_sub_account: "".to_string(),
             nonce: timestamp,
-            payload_multi_sig_user: Some(format!("{:#x}", multi_sig_user).to_lowercase()),
-            outer_signer: Some(format!("{:#x}", self.wallet.address()).to_lowercase()),
+            multi_sig_ext: Some(MultiSigExtension {
+                payload_multi_sig_user: format!("{:#x}", multi_sig_user).to_lowercase(),
+                outer_signer: format!("{:#x}", self.wallet.address()).to_lowercase(),
+            }),
         };
 
         let signatures = sign_typed_data_multi_sig(&send_asset, wallets)?;
@@ -1249,8 +1250,10 @@ impl ExchangeClient {
             amount: amount.to_string(),
             from_sub_account: "".to_string(),
             nonce: timestamp,
-            payload_multi_sig_user: Some(format!("{:#x}", multi_sig_user).to_lowercase()),
-            outer_signer: Some(format!("{:#x}", self.wallet.address()).to_lowercase()),
+            multi_sig_ext: Some(MultiSigExtension {
+                payload_multi_sig_user: format!("{:#x}", multi_sig_user).to_lowercase(),
+                outer_signer: format!("{:#x}", self.wallet.address()).to_lowercase(),
+            }),
         };
 
         let signatures = sign_typed_data_multi_sig(&send_asset, wallets)?;
@@ -1299,8 +1302,10 @@ impl ExchangeClient {
     ///     amount: "100".to_string(),
     ///     from_sub_account: "".to_string(),
     ///     nonce: 123456789,
+    ///     multi_sig_ext: Some(MultiSigExtension {
     ///     payload_multi_sig_user: Some(format!("{:#x}", multi_sig_user).to_lowercase()),
-    ///     outer_signer: Some("0x...".to_lowercase()),
+    ///         outer_signer: Some("0x...".to_lowercase()),
+    ///     }),
     /// };
     ///
     /// let sig1 = sign_multi_sig_user_signed_action_single(&wallet1, &send_asset)?;
@@ -1340,8 +1345,10 @@ impl ExchangeClient {
             amount: amount.to_string(),
             from_sub_account: "".to_string(),
             nonce: timestamp,
-            payload_multi_sig_user: Some(format!("{:#x}", multi_sig_user).to_lowercase()),
-            outer_signer: Some(format!("{:#x}", self.wallet.address()).to_lowercase()),
+            multi_sig_ext: Some(MultiSigExtension {
+                payload_multi_sig_user: format!("{:#x}", multi_sig_user).to_lowercase(),
+                outer_signer: format!("{:#x}", self.wallet.address()).to_lowercase(),
+            }),
         };
 
         let mut action =
@@ -1391,8 +1398,10 @@ impl ExchangeClient {
             amount: amount.to_string(),
             from_sub_account: "".to_string(),
             nonce: timestamp,
-            payload_multi_sig_user: Some(format!("{:#x}", multi_sig_user).to_lowercase()),
-            outer_signer: Some(format!("{:#x}", self.wallet.address()).to_lowercase()),
+            multi_sig_ext: Some(MultiSigExtension {
+                payload_multi_sig_user: format!("{:#x}", multi_sig_user).to_lowercase(),
+                outer_signer: format!("{:#x}", self.wallet.address()).to_lowercase(),
+            }),
         };
 
         let mut action =
@@ -1659,8 +1668,7 @@ mod tests {
             amount: "100".to_string(),
             from_sub_account: "".to_string(),
             nonce: 1583838,
-            payload_multi_sig_user: None,
-            outer_signer: None,
+            multi_sig_ext: None,
         };
 
         let mainnet_signature = sign_typed_data(&mainnet_send, &wallet)?;
@@ -1675,8 +1683,7 @@ mod tests {
             amount: "50".to_string(),
             from_sub_account: "".to_string(),
             nonce: 1583838,
-            payload_multi_sig_user: None,
-            outer_signer: None,
+            multi_sig_ext: None,
         };
 
         let testnet_signature = sign_typed_data(&testnet_send, &wallet)?;
@@ -1692,8 +1699,7 @@ mod tests {
             amount: "100".to_string(),
             from_sub_account: "0xabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd".to_string(),
             nonce: 1583838,
-            payload_multi_sig_user: None,
-            outer_signer: None,
+            multi_sig_ext: None,
         };
 
         let vault_signature = sign_typed_data(&vault_send, &wallet)?;

--- a/src/exchange/exchange_client.rs
+++ b/src/exchange/exchange_client.rs
@@ -62,7 +62,7 @@ struct ExchangePayload {
     signature: Signature,
     nonce: u64,
     #[serde(skip_serializing_if = "Option::is_none")]
-    vault_address: Option<Address>,
+    vault_address: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     expires_after: Option<u64>,
 }
@@ -71,8 +71,8 @@ struct ExchangePayload {
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct MultiSigPayload {
-    multi_sig_user: Address,
-    outer_signer: Address,
+    multi_sig_user: String,
+    outer_signer: String,
     action: serde_json::Value,
 }
 
@@ -245,6 +245,7 @@ impl ExchangeClient {
                 None
             } else {
                 self.vault_address
+                    .map(|addr| addr.to_string().to_lowercase())
             },
             expires_after: if should_exclude {
                 None
@@ -978,8 +979,8 @@ impl ExchangeClient {
             signature_chain_id: "0x66eee".to_string(),
             signatures: inner_signatures,
             payload: MultiSigPayload {
-                multi_sig_user,
-                outer_signer: self.wallet.address(),
+                multi_sig_user: multi_sig_user.to_string().to_lowercase(),
+                outer_signer: self.wallet.address().to_string().to_lowercase(),
                 action: inner_action,
             },
         };
@@ -1800,8 +1801,8 @@ mod tests {
             signature_chain_id: "0x66eee".to_string(),
             signatures: vec![sig],
             payload: MultiSigPayload {
-                multi_sig_user,
-                outer_signer: wallet.address(),
+                multi_sig_user: multi_sig_user.to_string().to_lowercase(),
+                outer_signer: wallet.address().to_string().to_lowercase(),
                 action: inner_action,
             },
         };

--- a/src/exchange/exchange_client.rs
+++ b/src/exchange/exchange_client.rs
@@ -1217,7 +1217,7 @@ impl ExchangeClient {
         let mut action =
             serde_json::to_value(&send_asset).map_err(|e| Error::JsonParse(e.to_string()))?;
         if let Some(obj) = action.as_object_mut() {
-            obj.insert("type".to_string(), serde_json::json!("sendAsset"));
+            obj.shift_insert(0, "type".to_string(), serde_json::json!("sendAsset"));
         }
 
         self.post_multi_sig(multi_sig_user, action, signatures, timestamp)
@@ -1262,7 +1262,7 @@ impl ExchangeClient {
         let mut action =
             serde_json::to_value(&send_asset).map_err(|e| Error::JsonParse(e.to_string()))?;
         if let Some(obj) = action.as_object_mut() {
-            obj.insert("type".to_string(), serde_json::json!("sendAsset"));
+            obj.shift_insert(0, "type".to_string(), serde_json::json!("sendAsset"));
         }
 
         self.post_multi_sig(multi_sig_user, action, signatures, timestamp)
@@ -1355,7 +1355,7 @@ impl ExchangeClient {
         let mut action =
             serde_json::to_value(&send_asset).map_err(|e| Error::JsonParse(e.to_string()))?;
         if let Some(obj) = action.as_object_mut() {
-            obj.insert("type".to_string(), serde_json::json!("sendAsset"));
+            obj.shift_insert(0, "type".to_string(), serde_json::json!("sendAsset"));
         }
 
         self.post_multi_sig(multi_sig_user, action, signatures, timestamp)
@@ -1408,7 +1408,7 @@ impl ExchangeClient {
         let mut action =
             serde_json::to_value(&send_asset).map_err(|e| Error::JsonParse(e.to_string()))?;
         if let Some(obj) = action.as_object_mut() {
-            obj.insert("type".to_string(), serde_json::json!("sendAsset"));
+            obj.shift_insert(0, "type".to_string(), serde_json::json!("sendAsset"));
         }
 
         self.post_multi_sig(multi_sig_user, action, signatures, timestamp)

--- a/src/exchange/exchange_client.rs
+++ b/src/exchange/exchange_client.rs
@@ -1186,7 +1186,7 @@ impl ExchangeClient {
             "Testnet".to_string()
         };
 
-        let timestamp = next_nonce();
+        let timestamp = 1762838147000;
 
         let send_asset = SendAsset {
             signature_chain_id: 421614,

--- a/src/exchange/exchange_client.rs
+++ b/src/exchange/exchange_client.rs
@@ -1194,7 +1194,7 @@ impl ExchangeClient {
             "Testnet".to_string()
         };
 
-        let timestamp = next_nonce();
+        let timestamp = 1762838147000;
 
         let send_asset = SendAsset {
             signature_chain_id: 421614,

--- a/src/exchange/exchange_client.rs
+++ b/src/exchange/exchange_client.rs
@@ -80,7 +80,7 @@ struct MultiSigPayload {
 pub(crate) struct MultiSigAction {
     #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
     pub r#type: Option<String>,
-    signature_chain_id: String,
+    pub signature_chain_id: String,
     #[serde(serialize_with = "serialize_sigs")]
     signatures: Vec<Signature>,
     payload: MultiSigPayload,

--- a/src/exchange/exchange_client.rs
+++ b/src/exchange/exchange_client.rs
@@ -19,8 +19,8 @@ use crate::{
         sign_l1_action, sign_multi_sig_action, sign_multi_sig_l1_action_payload, sign_typed_data,
         sign_typed_data_multi_sig,
     },
-    BulkCancelCloid, ClassTransfer, Error, ExchangeResponseStatus, HyperliquidChain,
-    MultiSigExtension, SpotSend, SpotUser, VaultTransfer, Withdraw3,
+    BulkCancelCloid, Error, ExchangeResponseStatus, HyperliquidChain, MultiSigExtension, SpotSend,
+    UsdClassTransfer, VaultTransfer, Withdraw3,
 };
 use alloy::{
     hex,
@@ -123,7 +123,7 @@ pub enum Actions {
     BatchModify(BulkModify),
     ApproveAgent(ApproveAgent),
     Withdraw3(Withdraw3),
-    SpotUser(SpotUser),
+    UsdClassTransfer(UsdClassTransfer),
     SendAsset(SendAsset),
     VaultTransfer(VaultTransfer),
     SpotSend(SpotSend),
@@ -237,7 +237,7 @@ impl ExchangeClient {
                 | Actions::Withdraw3(_)
                 | Actions::SpotSend(_)
                 | Actions::SendAsset(_)
-                | Actions::SpotUser(_)
+                | Actions::UsdClassTransfer(_)
         )
     }
 
@@ -320,24 +320,19 @@ impl ExchangeClient {
         self.post(action, signature, timestamp).await
     }
 
-    pub async fn class_transfer(
+    pub async fn usd_class_transfer(
         &self,
-        usdc: f64,
+        amount: f64,
         to_perp: bool,
         wallet: Option<&PrivateKeySigner>,
     ) -> Result<ExchangeResponseStatus> {
-        // payload expects usdc without decimals
-        let usdc = (usdc * 1e6).round() as u64;
         let wallet = wallet.unwrap_or(&self.wallet);
 
-        let timestamp = next_nonce();
-
-        let action = Actions::SpotUser(SpotUser {
-            class_transfer: ClassTransfer { usdc, to_perp },
-        });
-        let connection_id = action.hash(timestamp, self.vault_address, self.expires_after)?;
-        let is_mainnet = self.http_client.is_mainnet();
-        let signature = sign_l1_action(wallet, connection_id, is_mainnet)?;
+        let usd_class_transfer =
+            UsdClassTransfer::new(self.http_client.chain, amount.to_string(), to_perp);
+        let timestamp = usd_class_transfer.nonce;
+        let signature = sign_typed_data(&usd_class_transfer, wallet)?;
+        let action = Actions::UsdClassTransfer(usd_class_transfer);
 
         self.post(action, signature, timestamp).await
     }

--- a/src/exchange/exchange_client.rs
+++ b/src/exchange/exchange_client.rs
@@ -138,7 +138,7 @@ pub enum Actions {
 
 #[derive(Serialize)]
 #[serde(untagged)]
-enum PostAction {
+pub enum PostAction {
     Std(Actions),
     MultiSig(MultiSigAction),
 }
@@ -241,7 +241,7 @@ impl ExchangeClient {
         )
     }
 
-    async fn post<PA: Into<PostAction>>(
+    pub async fn post<PA: Into<PostAction>>(
         &self,
         action: PA,
         signature: Signature,

--- a/src/exchange/exchange_client.rs
+++ b/src/exchange/exchange_client.rs
@@ -19,8 +19,8 @@ use crate::{
         sign_l1_action, sign_multi_sig_action, sign_multi_sig_l1_action_payload, sign_typed_data,
         sign_typed_data_multi_sig,
     },
-    BaseUrl, BulkCancelCloid, ClassTransfer, Error, ExchangeResponseStatus, MultiSigExtension,
-    SpotSend, SpotUser, VaultTransfer, Withdraw3,
+    BulkCancelCloid, ClassTransfer, Error, ExchangeResponseStatus, HyperliquidChain,
+    MultiSigExtension, SpotSend, SpotUser, VaultTransfer, Withdraw3,
 };
 use alloy::{
     hex,
@@ -183,12 +183,12 @@ impl ExchangeClient {
     pub async fn new(
         client: Option<Client>,
         wallet: PrivateKeySigner,
-        base_url: Option<BaseUrl>,
+        base_url: Option<HyperliquidChain>,
         meta: Option<Meta>,
         vault_address: Option<Address>,
     ) -> Result<ExchangeClient> {
         let client = client.unwrap_or_default();
-        let base_url = base_url.unwrap_or(BaseUrl::Mainnet);
+        let base_url = base_url.unwrap_or(HyperliquidChain::Mainnet);
 
         let info = InfoClient::new(None, Some(base_url)).await?;
         let meta = if let Some(meta) = meta {
@@ -213,7 +213,7 @@ impl ExchangeClient {
             vault_address,
             http_client: HttpClient {
                 client,
-                base_url: base_url.get_url(),
+                chain: base_url,
             },
             coin_to_asset,
             expires_after: None,
@@ -307,24 +307,17 @@ impl ExchangeClient {
         wallet: Option<&PrivateKeySigner>,
     ) -> Result<ExchangeResponseStatus> {
         let wallet = wallet.unwrap_or(&self.wallet);
-        let hyperliquid_chain = if self.http_client.is_mainnet() {
-            "Mainnet".to_string()
-        } else {
-            "Testnet".to_string()
-        };
+        let usd_send = UsdSend::new(
+            self.http_client.chain,
+            destination.to_lowercase(),
+            amount.to_string(),
+            None,
+        );
+        let timestamp = usd_send.time;
+        let signature = sign_typed_data(&usd_send, wallet)?;
+        let action = Actions::UsdSend(usd_send);
 
-        let timestamp = next_nonce();
-        let action = UsdSend {
-            signature_chain_id: 421614,
-            hyperliquid_chain,
-            destination: destination.to_lowercase(),
-            amount: amount.to_string(),
-            time: timestamp,
-        };
-        let signature = sign_typed_data(&action, wallet)?;
-
-        self.post(Actions::UsdSend(action), signature, timestamp)
-            .await
+        self.post(action, signature, timestamp).await
     }
 
     pub async fn class_transfer(
@@ -360,35 +353,26 @@ impl ExchangeClient {
     ) -> Result<ExchangeResponseStatus> {
         let wallet = wallet.unwrap_or(&self.wallet);
 
-        let hyperliquid_chain = if self.http_client.is_mainnet() {
-            "Mainnet".to_string()
-        } else {
-            "Testnet".to_string()
-        };
-
-        let timestamp = next_nonce();
-
         // Build fromSubAccount string (similar to Python SDK)
         let from_sub_account = self
             .vault_address
             .map_or_else(String::new, |vault_addr| format!("{vault_addr:?}"));
 
-        let action = SendAsset {
-            signature_chain_id: 421614,
-            hyperliquid_chain,
-            destination: destination.to_lowercase(),
-            source_dex: source_dex.to_string(),
-            destination_dex: destination_dex.to_string(),
-            token: token.to_string(),
-            amount: amount.to_string(),
+        let send_asset = SendAsset::new(
+            self.http_client.chain,
+            destination.to_lowercase(),
+            source_dex.to_string(),
+            destination_dex.to_string(),
+            token.to_string(),
+            amount.to_string(),
             from_sub_account,
-            nonce: timestamp,
-            multi_sig_ext: None,
-        };
+            None,
+            None,
+        );
+        let timestamp = send_asset.nonce;
+        let signature = sign_typed_data(&send_asset, wallet)?;
 
-        let signature = sign_typed_data(&action, wallet)?;
-
-        self.post(Actions::SendAsset(action), signature, timestamp)
+        self.post(Actions::SendAsset(send_asset), signature, timestamp)
             .await
     }
 
@@ -475,12 +459,7 @@ impl ExchangeClient {
         let slippage = params.slippage.unwrap_or(0.05); // Default 5% slippage
         let wallet = params.wallet.unwrap_or(&self.wallet);
 
-        let base_url = match self.http_client.base_url.as_str() {
-            "https://api.hyperliquid.xyz" => BaseUrl::Mainnet,
-            "https://api.hyperliquid-testnet.xyz" => BaseUrl::Testnet,
-            _ => return Err(Error::GenericRequest("Invalid base URL".to_string())),
-        };
-        let info_client = InfoClient::new(None, Some(base_url)).await?;
+        let info_client = InfoClient::new(None, Some(self.http_client.chain)).await?;
         let user_state = info_client.user_state(wallet.address()).await?;
 
         let position = user_state
@@ -523,12 +502,7 @@ impl ExchangeClient {
         slippage: f64,
         px: Option<f64>,
     ) -> Result<(f64, u32)> {
-        let base_url = match self.http_client.base_url.as_str() {
-            "https://api.hyperliquid.xyz" => BaseUrl::Mainnet,
-            "https://api.hyperliquid-testnet.xyz" => BaseUrl::Testnet,
-            _ => return Err(Error::GenericRequest("Invalid base URL".to_string())),
-        };
-        let info_client = InfoClient::new(None, Some(base_url)).await?;
+        let info_client = InfoClient::new(None, Some(self.http_client.chain)).await?;
         let meta = info_client.meta().await?;
 
         let asset_meta = meta
@@ -813,21 +787,8 @@ impl ExchangeClient {
     ) -> Result<(B256, ExchangeResponseStatus)> {
         let wallet = wallet.unwrap_or(&self.wallet);
         let agent = PrivateKeySigner::random();
-
-        let hyperliquid_chain = if self.http_client.is_mainnet() {
-            "Mainnet".to_string()
-        } else {
-            "Testnet".to_string()
-        };
-
-        let nonce = next_nonce();
-        let approve_agent = ApproveAgent {
-            signature_chain_id: 421614,
-            hyperliquid_chain,
-            agent_address: agent.address(),
-            agent_name: None,
-            nonce,
-        };
+        let approve_agent = ApproveAgent::new(self.http_client.chain, agent.address(), None, None);
+        let nonce = approve_agent.nonce;
         let signature = sign_typed_data(&approve_agent, wallet)?;
         let action = Actions::ApproveAgent(approve_agent);
         Ok((agent.to_bytes(), self.post(action, signature, nonce).await?))
@@ -840,20 +801,13 @@ impl ExchangeClient {
         wallet: Option<&PrivateKeySigner>,
     ) -> Result<ExchangeResponseStatus> {
         let wallet = wallet.unwrap_or(&self.wallet);
-        let hyperliquid_chain = if self.http_client.is_mainnet() {
-            "Mainnet".to_string()
-        } else {
-            "Testnet".to_string()
-        };
-
-        let timestamp = next_nonce();
-        let withdraw = Withdraw3 {
-            signature_chain_id: 421614,
-            hyperliquid_chain,
-            destination: destination.to_lowercase(),
-            amount: amount.to_string(),
-            time: timestamp,
-        };
+        let withdraw = Withdraw3::new(
+            self.http_client.chain,
+            destination.to_lowercase(),
+            amount.to_string(),
+            None,
+        );
+        let timestamp = withdraw.time;
         let signature = sign_typed_data(&withdraw, wallet)?;
         let action = Actions::Withdraw3(withdraw);
 
@@ -868,21 +822,14 @@ impl ExchangeClient {
         wallet: Option<&PrivateKeySigner>,
     ) -> Result<ExchangeResponseStatus> {
         let wallet = wallet.unwrap_or(&self.wallet);
-        let hyperliquid_chain = if self.http_client.is_mainnet() {
-            "Mainnet".to_string()
-        } else {
-            "Testnet".to_string()
-        };
-
-        let timestamp = next_nonce();
-        let spot_send = SpotSend {
-            signature_chain_id: 421614,
-            hyperliquid_chain,
-            destination: destination.to_lowercase(),
-            amount: amount.to_string(),
-            time: timestamp,
-            token: token.to_string(),
-        };
+        let spot_send = SpotSend::new(
+            self.http_client.chain,
+            destination.to_lowercase(),
+            token.to_string(),
+            amount.to_string(),
+            None,
+        );
+        let timestamp = spot_send.time;
         let signature = sign_typed_data(&spot_send, wallet)?;
         let action = Actions::SpotSend(spot_send);
 
@@ -913,21 +860,9 @@ impl ExchangeClient {
         wallet: Option<&PrivateKeySigner>,
     ) -> Result<ExchangeResponseStatus> {
         let wallet = wallet.unwrap_or(&self.wallet);
-        let timestamp = next_nonce();
-
-        let hyperliquid_chain = if self.http_client.is_mainnet() {
-            "Mainnet".to_string()
-        } else {
-            "Testnet".to_string()
-        };
-
-        let approve_builder_fee = ApproveBuilderFee {
-            signature_chain_id: 421614,
-            hyperliquid_chain,
-            builder,
-            max_fee_rate,
-            nonce: timestamp,
-        };
+        let approve_builder_fee =
+            ApproveBuilderFee::new(self.http_client.chain, builder, max_fee_rate, None);
+        let timestamp = approve_builder_fee.nonce;
         let signature = sign_typed_data(&approve_builder_fee, wallet)?;
         let action = Actions::ApproveBuilderFee(approve_builder_fee);
 
@@ -1005,20 +940,9 @@ impl ExchangeClient {
         wallet: Option<&PrivateKeySigner>,
     ) -> Result<ExchangeResponseStatus> {
         let wallet = wallet.unwrap_or(&self.wallet);
-        let timestamp = next_nonce();
-
-        let hyperliquid_chain = if self.http_client.is_mainnet() {
-            "Mainnet".to_string()
-        } else {
-            "Testnet".to_string()
-        };
-
-        let convert_to_multi_sig = ConvertToMultiSig {
-            signature_chain_id: 421614,
-            hyperliquid_chain,
-            multi_sig_threshold,
-            time: timestamp,
-        };
+        let convert_to_multi_sig =
+            ConvertToMultiSig::new(self.http_client.chain, multi_sig_threshold, None);
+        let timestamp = convert_to_multi_sig.time;
         let signature = sign_typed_data(&convert_to_multi_sig, wallet)?;
         let action = Actions::ConvertToMultiSig(convert_to_multi_sig);
 
@@ -1033,21 +957,9 @@ impl ExchangeClient {
         wallet: Option<&PrivateKeySigner>,
     ) -> Result<ExchangeResponseStatus> {
         let wallet = wallet.unwrap_or(&self.wallet);
-        let timestamp = next_nonce();
-
-        let hyperliquid_chain = if self.http_client.is_mainnet() {
-            "Mainnet".to_string()
-        } else {
-            "Testnet".to_string()
-        };
-
-        let update_multi_sig_addresses = UpdateMultiSigAddresses {
-            signature_chain_id: 421614,
-            hyperliquid_chain,
-            to_add,
-            to_remove,
-            time: timestamp,
-        };
+        let update_multi_sig_addresses =
+            UpdateMultiSigAddresses::new(self.http_client.chain, to_add, to_remove, None);
+        let timestamp = update_multi_sig_addresses.time;
         let signature = sign_typed_data(&update_multi_sig_addresses, wallet)?;
         let action = Actions::UpdateMultiSigAddresses(update_multi_sig_addresses);
 
@@ -1180,30 +1092,21 @@ impl ExchangeClient {
         destination: &str,
         wallets: &[PrivateKeySigner],
     ) -> Result<ExchangeResponseStatus> {
-        let hyperliquid_chain = if self.http_client.is_mainnet() {
-            "Mainnet".to_string()
-        } else {
-            "Testnet".to_string()
-        };
-
-        let timestamp = next_nonce();
-
-        let send_asset = SendAsset {
-            signature_chain_id: 421614,
-            hyperliquid_chain,
-            destination: destination.to_lowercase(),
-            source_dex: "".to_string(),
-            destination_dex: "".to_string(),
-            token: "USDC".to_string(),
-            amount: amount.to_string(),
-            from_sub_account: "".to_string(),
-            nonce: timestamp,
-            multi_sig_ext: Some(MultiSigExtension {
+        let send_asset = SendAsset::new(
+            self.http_client.chain,
+            destination.to_lowercase(),
+            "".to_string(),
+            "".to_string(),
+            "USDC".to_string(),
+            amount.to_string(),
+            "".to_string(),
+            Some(MultiSigExtension {
                 payload_multi_sig_user: format!("{:#x}", multi_sig_user).to_lowercase(),
                 outer_signer: format!("{:#x}", self.wallet.address()).to_lowercase(),
             }),
-        };
-
+            None,
+        );
+        let timestamp = send_asset.nonce;
         let signatures = sign_typed_data_multi_sig(&send_asset, wallets)?;
 
         self.post_multi_sig(
@@ -1224,30 +1127,21 @@ impl ExchangeClient {
         token: &str,
         wallets: &[PrivateKeySigner],
     ) -> Result<ExchangeResponseStatus> {
-        let hyperliquid_chain = if self.http_client.is_mainnet() {
-            "Mainnet".to_string()
-        } else {
-            "Testnet".to_string()
-        };
-
-        let timestamp = next_nonce();
-
-        let send_asset = SendAsset {
-            signature_chain_id: 421614,
-            hyperliquid_chain,
-            destination: destination.to_lowercase(),
-            source_dex: "".to_string(),
-            destination_dex: "".to_string(),
-            token: token.to_string(),
-            amount: amount.to_string(),
-            from_sub_account: "".to_string(),
-            nonce: timestamp,
-            multi_sig_ext: Some(MultiSigExtension {
+        let send_asset = SendAsset::new(
+            self.http_client.chain,
+            destination.to_lowercase(),
+            "".to_string(),
+            "".to_string(),
+            token.to_string(),
+            amount.to_string(),
+            "".to_string(),
+            Some(MultiSigExtension {
                 payload_multi_sig_user: format!("{:#x}", multi_sig_user).to_lowercase(),
                 outer_signer: format!("{:#x}", self.wallet.address()).to_lowercase(),
             }),
-        };
-
+            None,
+        );
+        let timestamp = send_asset.nonce;
         let signatures = sign_typed_data_multi_sig(&send_asset, wallets)?;
 
         self.post_multi_sig(
@@ -1318,29 +1212,21 @@ impl ExchangeClient {
         destination: &str,
         signatures: Vec<Signature>,
     ) -> Result<ExchangeResponseStatus> {
-        let hyperliquid_chain = if self.http_client.is_mainnet() {
-            "Mainnet".to_string()
-        } else {
-            "Testnet".to_string()
-        };
-
-        let timestamp = next_nonce();
-
-        let send_asset = SendAsset {
-            signature_chain_id: 421614,
-            hyperliquid_chain,
-            destination: destination.to_lowercase(),
-            source_dex: "".to_string(),
-            destination_dex: "".to_string(),
-            token: "USDC".to_string(),
-            amount: amount.to_string(),
-            from_sub_account: "".to_string(),
-            nonce: timestamp,
-            multi_sig_ext: Some(MultiSigExtension {
+        let send_asset = SendAsset::new(
+            self.http_client.chain,
+            destination.to_lowercase(),
+            "".to_string(),
+            "".to_string(),
+            "USDC".to_string(),
+            amount.to_string(),
+            "".to_string(),
+            Some(MultiSigExtension {
                 payload_multi_sig_user: format!("{:#x}", multi_sig_user).to_lowercase(),
                 outer_signer: format!("{:#x}", self.wallet.address()).to_lowercase(),
             }),
-        };
+            None,
+        );
+        let timestamp = send_asset.nonce;
 
         self.post_multi_sig(
             multi_sig_user,
@@ -1370,29 +1256,21 @@ impl ExchangeClient {
         token: &str,
         signatures: Vec<Signature>,
     ) -> Result<ExchangeResponseStatus> {
-        let hyperliquid_chain = if self.http_client.is_mainnet() {
-            "Mainnet".to_string()
-        } else {
-            "Testnet".to_string()
-        };
-
-        let timestamp = next_nonce();
-
-        let send_asset = SendAsset {
-            signature_chain_id: 421614,
-            hyperliquid_chain,
-            destination: destination.to_lowercase(),
-            source_dex: "".to_string(),
-            destination_dex: "".to_string(),
-            token: token.to_string(),
-            amount: amount.to_string(),
-            from_sub_account: "".to_string(),
-            nonce: timestamp,
-            multi_sig_ext: Some(MultiSigExtension {
+        let send_asset = SendAsset::new(
+            self.http_client.chain,
+            destination.to_lowercase(),
+            "".to_string(),
+            "".to_string(),
+            token.to_string(),
+            amount.to_string(),
+            "".to_string(),
+            Some(MultiSigExtension {
                 payload_multi_sig_user: format!("{:#x}", multi_sig_user).to_lowercase(),
                 outer_signer: format!("{:#x}", self.wallet.address()).to_lowercase(),
             }),
-        };
+            None,
+        );
+        let timestamp = send_asset.nonce;
 
         self.post_multi_sig(
             multi_sig_user,

--- a/src/exchange/exchange_client.rs
+++ b/src/exchange/exchange_client.rs
@@ -3,7 +3,8 @@ use crate::{
         actions::{
             ApproveAgent, ApproveBuilderFee, BulkCancel, BulkModify, BulkOrder, ClaimRewards,
             ConvertToMultiSig, CreateSubAccount, EvmUserModify, ScheduleCancel, SendAsset,
-            SetReferrer, UpdateIsolatedMargin, UpdateLeverage, UpdateMultiSigAddresses, UsdSend,
+            SetReferrer, SubAccountSpotTransfer, SubAccountTransfer, UpdateIsolatedMargin,
+            UpdateLeverage, UpdateMultiSigAddresses, UsdSend,
         },
         cancel::{CancelRequest, CancelRequestCloid, ClientCancelRequestCloid},
         modify::{ClientModifyRequest, ModifyRequest},
@@ -129,6 +130,8 @@ pub enum Actions {
     SpotSend(SpotSend),
     SetReferrer(SetReferrer),
     CreateSubAccount(CreateSubAccount),
+    SubAccountTransfer(SubAccountTransfer),
+    SubAccountSpotTransfer(SubAccountSpotTransfer),
     ApproveBuilderFee(ApproveBuilderFee),
     EvmUserModify(EvmUserModify),
     ScheduleCancel(ScheduleCancel),

--- a/src/exchange/exchange_client.rs
+++ b/src/exchange/exchange_client.rs
@@ -2,8 +2,8 @@ use crate::{
     exchange::{
         actions::{
             ApproveAgent, ApproveBuilderFee, BulkCancel, BulkModify, BulkOrder, ClaimRewards,
-            ConvertToMultiSig, EvmUserModify, ScheduleCancel, SendAsset, SetReferrer,
-            UpdateIsolatedMargin, UpdateLeverage, UpdateMultiSigAddresses, UsdSend,
+            ConvertToMultiSig, CreateSubAccount, EvmUserModify, ScheduleCancel, SendAsset,
+            SetReferrer, UpdateIsolatedMargin, UpdateLeverage, UpdateMultiSigAddresses, UsdSend,
         },
         cancel::{CancelRequest, CancelRequestCloid, ClientCancelRequestCloid},
         modify::{ClientModifyRequest, ModifyRequest},
@@ -128,6 +128,7 @@ pub enum Actions {
     VaultTransfer(VaultTransfer),
     SpotSend(SpotSend),
     SetReferrer(SetReferrer),
+    CreateSubAccount(CreateSubAccount),
     ApproveBuilderFee(ApproveBuilderFee),
     EvmUserModify(EvmUserModify),
     ScheduleCancel(ScheduleCancel),
@@ -845,6 +846,25 @@ impl ExchangeClient {
 
         let is_mainnet = self.http_client.is_mainnet();
         let signature = sign_l1_action(wallet, connection_id, is_mainnet)?;
+        self.post(action, signature, timestamp).await
+    }
+
+    /// Create a sub-account under the master account.
+    ///
+    /// On success, the sub-account address is returned in the exchange response.
+    pub async fn create_sub_account(
+        &self,
+        name: String,
+        wallet: Option<&PrivateKeySigner>,
+    ) -> Result<ExchangeResponseStatus> {
+        let wallet = wallet.unwrap_or(&self.wallet);
+        let timestamp = next_nonce();
+
+        let action = Actions::CreateSubAccount(CreateSubAccount { name });
+        let connection_id = action.hash(timestamp, self.vault_address, self.expires_after)?;
+        let is_mainnet = self.http_client.is_mainnet();
+        let signature = sign_l1_action(wallet, connection_id, is_mainnet)?;
+
         self.post(action, signature, timestamp).await
     }
 

--- a/src/exchange/exchange_client.rs
+++ b/src/exchange/exchange_client.rs
@@ -77,7 +77,7 @@ struct MultiSigPayload {
 
 #[derive(Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub(crate) struct MultiSigAction {
+pub struct MultiSigAction {
     #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
     pub r#type: Option<String>,
     pub signature_chain_id: String,
@@ -156,7 +156,7 @@ impl From<MultiSigAction> for PostAction {
 }
 
 impl Actions {
-    fn hash(
+    pub fn hash(
         &self,
         timestamp: u64,
         vault_address: Option<Address>,

--- a/src/exchange/mod.rs
+++ b/src/exchange/mod.rs
@@ -1,4 +1,4 @@
-mod actions;
+pub mod actions;
 mod builder;
 mod cancel;
 mod exchange_client;

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,3 +1,4 @@
+use std::fmt::Display;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use chrono::prelude::Utc;
@@ -71,18 +72,36 @@ pub fn bps_diff(x: f64, y: f64) -> u16 {
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub enum BaseUrl {
+pub enum HyperliquidChain {
     Localhost,
     Testnet,
     Mainnet,
 }
 
-impl BaseUrl {
-    pub(crate) fn get_url(&self) -> String {
+impl HyperliquidChain {
+    pub(crate) fn url(&self) -> &'static str {
         match self {
-            BaseUrl::Localhost => LOCAL_API_URL.to_string(),
-            BaseUrl::Mainnet => MAINNET_API_URL.to_string(),
-            BaseUrl::Testnet => TESTNET_API_URL.to_string(),
+            HyperliquidChain::Localhost => LOCAL_API_URL,
+            HyperliquidChain::Mainnet => MAINNET_API_URL,
+            HyperliquidChain::Testnet => TESTNET_API_URL,
+        }
+    }
+
+    pub(crate) fn action_chain_name(&self) -> String {
+        self.to_string()
+    }
+
+    pub fn is_mainnet(&self) -> bool {
+        *self == HyperliquidChain::Mainnet
+    }
+}
+
+impl Display for HyperliquidChain {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            HyperliquidChain::Localhost => write!(f, "Localhost"),
+            HyperliquidChain::Mainnet => write!(f, "Mainnet"),
+            HyperliquidChain::Testnet => write!(f, "Testnet"),
         }
     }
 }

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -70,7 +70,7 @@ pub fn bps_diff(x: f64, y: f64) -> u16 {
     }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum BaseUrl {
     Localhost,
     Testnet,

--- a/src/info/info_client.rs
+++ b/src/info/info_client.rs
@@ -15,7 +15,7 @@ use crate::{
     prelude::*,
     req::HttpClient,
     ws::{Subscription, WsManager},
-    BaseUrl, Error, Message, OrderStatusResponse, ReferralResponse, UserFeesResponse,
+    Error, HyperliquidChain, Message, OrderStatusResponse, ReferralResponse, UserFeesResponse,
     UserFundingResponse, UserTokenBalanceResponse,
 };
 
@@ -104,27 +104,33 @@ pub struct InfoClient {
 }
 
 impl InfoClient {
-    pub async fn new(client: Option<Client>, base_url: Option<BaseUrl>) -> Result<InfoClient> {
+    pub async fn new(
+        client: Option<Client>,
+        base_url: Option<HyperliquidChain>,
+    ) -> Result<InfoClient> {
         Self::new_internal(client, base_url, false).await
     }
 
     pub async fn with_reconnect(
         client: Option<Client>,
-        base_url: Option<BaseUrl>,
+        base_url: Option<HyperliquidChain>,
     ) -> Result<InfoClient> {
         Self::new_internal(client, base_url, true).await
     }
 
     async fn new_internal(
         client: Option<Client>,
-        base_url: Option<BaseUrl>,
+        base_url: Option<HyperliquidChain>,
         reconnect: bool,
     ) -> Result<InfoClient> {
         let client = client.unwrap_or_default();
-        let base_url = base_url.unwrap_or(BaseUrl::Mainnet).get_url();
+        let base_url = base_url.unwrap_or(HyperliquidChain::Mainnet);
 
         Ok(InfoClient {
-            http_client: HttpClient { client, base_url },
+            http_client: HttpClient {
+                client,
+                chain: base_url,
+            },
             ws_manager: None,
             reconnect,
         })
@@ -137,7 +143,7 @@ impl InfoClient {
     ) -> Result<u32> {
         if self.ws_manager.is_none() {
             let ws_manager = WsManager::new(
-                format!("ws{}/ws", &self.http_client.base_url[4..]),
+                format!("ws{}/ws", &self.http_client.chain.url()[4..]),
                 self.reconnect,
             )
             .await?;
@@ -157,7 +163,7 @@ impl InfoClient {
     pub async fn unsubscribe(&mut self, subscription_id: u32) -> Result<()> {
         if self.ws_manager.is_none() {
             let ws_manager = WsManager::new(
-                format!("ws{}/ws", &self.http_client.base_url[4..]),
+                format!("ws{}/ws", &self.http_client.chain.url()[4..]),
                 self.reconnect,
             )
             .await?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,4 +19,5 @@ pub use helpers::{bps_diff, truncate_float, BaseUrl};
 pub use info::{info_client::*, *};
 pub use market_maker::{MarketMaker, MarketMakerInput, MarketMakerRestingOrder};
 pub use meta::{AssetContext, AssetMeta, Meta, MetaAndAssetCtxs, SpotAssetMeta, SpotMeta};
+pub use signature::{sign_multi_sig_l1_action_single, sign_multi_sig_user_signed_action_single};
 pub use ws::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ pub use consts::{EPSILON, LOCAL_API_URL, MAINNET_API_URL, TESTNET_API_URL};
 pub use eip712::Eip712;
 pub use errors::Error;
 pub use exchange::*;
-pub use helpers::{bps_diff, truncate_float, BaseUrl};
+pub use helpers::{bps_diff, truncate_float, HyperliquidChain};
 pub use info::{info_client::*, *};
 pub use market_maker::{MarketMaker, MarketMakerInput, MarketMakerRestingOrder};
 pub use meta::{AssetContext, AssetMeta, Meta, MetaAndAssetCtxs, SpotAssetMeta, SpotMeta};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,5 +19,5 @@ pub use helpers::{bps_diff, truncate_float, HyperliquidChain};
 pub use info::{info_client::*, *};
 pub use market_maker::{MarketMaker, MarketMakerInput, MarketMakerRestingOrder};
 pub use meta::{AssetContext, AssetMeta, Meta, MetaAndAssetCtxs, SpotAssetMeta, SpotMeta};
-pub use signature::{sign_multi_sig_l1_action_single, sign_multi_sig_user_signed_action_single};
+pub use signature::*;
 pub use ws::*;

--- a/src/market_maker.rs
+++ b/src/market_maker.rs
@@ -3,8 +3,8 @@ use log::{error, info};
 use tokio::sync::mpsc::unbounded_channel;
 
 use crate::{
-    bps_diff, truncate_float, BaseUrl, ClientCancelRequest, ClientLimit, ClientOrder,
-    ClientOrderRequest, ExchangeClient, ExchangeDataStatus, ExchangeResponseStatus, InfoClient,
+    bps_diff, truncate_float, ClientCancelRequest, ClientLimit, ClientOrder, ClientOrderRequest,
+    ExchangeClient, ExchangeDataStatus, ExchangeResponseStatus, HyperliquidChain, InfoClient,
     Message, Subscription, UserData, EPSILON,
 };
 #[derive(Debug)]
@@ -46,11 +46,18 @@ impl MarketMaker {
     pub async fn new(input: MarketMakerInput) -> MarketMaker {
         let user_address = input.wallet.address();
 
-        let info_client = InfoClient::new(None, Some(BaseUrl::Testnet)).await.unwrap();
-        let exchange_client =
-            ExchangeClient::new(None, input.wallet, Some(BaseUrl::Testnet), None, None)
-                .await
-                .unwrap();
+        let info_client = InfoClient::new(None, Some(HyperliquidChain::Testnet))
+            .await
+            .unwrap();
+        let exchange_client = ExchangeClient::new(
+            None,
+            input.wallet,
+            Some(HyperliquidChain::Testnet),
+            None,
+            None,
+        )
+        .await
+        .unwrap();
 
         MarketMaker {
             asset: input.asset,

--- a/src/req.rs
+++ b/src/req.rs
@@ -1,7 +1,7 @@
 use reqwest::{Client, Response};
 use serde::Deserialize;
 
-use crate::{prelude::*, BaseUrl, Error};
+use crate::{prelude::*, Error, HyperliquidChain};
 
 #[derive(Deserialize, Debug)]
 struct ErrorData {
@@ -13,7 +13,7 @@ struct ErrorData {
 #[derive(Debug)]
 pub struct HttpClient {
     pub client: Client,
-    pub base_url: String,
+    pub chain: HyperliquidChain,
 }
 
 async fn parse_response(response: Response) -> Result<String> {
@@ -53,7 +53,7 @@ async fn parse_response(response: Response) -> Result<String> {
 
 impl HttpClient {
     pub async fn post(&self, url_path: &'static str, data: String) -> Result<String> {
-        let full_url = format!("{}{url_path}", self.base_url);
+        let full_url = format!("{}{url_path}", self.chain.url());
         let request = self
             .client
             .post(full_url)
@@ -70,6 +70,6 @@ impl HttpClient {
     }
 
     pub fn is_mainnet(&self) -> bool {
-        self.base_url == BaseUrl::Mainnet.get_url()
+        self.chain.is_mainnet()
     }
 }

--- a/src/signature/agent.rs
+++ b/src/signature/agent.rs
@@ -1,4 +1,4 @@
-pub(crate) mod l1 {
+pub mod l1 {
     use alloy::{
         dyn_abi::Eip712Domain,
         primitives::{Address, B256},

--- a/src/signature/agent.rs
+++ b/src/signature/agent.rs
@@ -16,6 +16,16 @@ pub(crate) mod l1 {
         }
     }
 
+    impl Agent {
+        pub fn new(is_mainnet: bool, connection_id: B256) -> Agent {
+            let source = if is_mainnet { "a" } else { "b" }.to_string();
+            Agent {
+                source,
+                connectionId: connection_id,
+            }
+        }
+    }
+
     impl Eip712 for Agent {
         fn domain(&self) -> Eip712Domain {
             eip712_domain! {

--- a/src/signature/create_signature.rs
+++ b/src/signature/create_signature.rs
@@ -1,8 +1,5 @@
 use crate::{eip712::Eip712, prelude::*, signature::agent::l1, Error};
-use alloy::{
-    primitives::B256,
-    signers::{local::PrivateKeySigner, Signature, SignerSync},
-};
+use alloy::{hex, primitives::B256, signers::{local::PrivateKeySigner, Signature, SignerSync}};
 
 pub(crate) fn sign_l1_action(
     wallet: &PrivateKeySigner,
@@ -116,6 +113,7 @@ pub(crate) fn sign_multi_sig_action(
     let mut bytes = rmp_serde::to_vec_named(&action_without_type)
         .map_err(|e| Error::RmpParse(e.to_string()))?;
     println!("{}", action_without_type);
+    println!("{}", hex::encode(&bytes));
 
     bytes.extend(nonce.to_be_bytes());
 

--- a/src/signature/create_signature.rs
+++ b/src/signature/create_signature.rs
@@ -139,8 +139,19 @@ pub(crate) fn sign_multi_sig_action(
         "Testnet".to_string()
     };
 
+    let signature_chain_id = u64::from_str_radix(
+        multi_sig_action.signature_chain_id.trim_start_matches("0x"),
+        16,
+    )
+    .map_err(|_| {
+        Error::GenericParse(format!(
+            "Invalid signature chain ID: {}",
+            multi_sig_action.signature_chain_id
+        ))
+    })?;
+
     let envelope = MultiSigEnvelope {
-        signature_chain_id: 421614, // Always use this chain ID for multi-sig
+        signature_chain_id,
         hyperliquid_chain,
         multi_sig_action_hash,
         nonce,

--- a/src/signature/create_signature.rs
+++ b/src/signature/create_signature.rs
@@ -2,7 +2,6 @@ use alloy::{
     primitives::B256,
     signers::{local::PrivateKeySigner, Signature, SignerSync},
 };
-
 use crate::{eip712::Eip712, prelude::*, signature::agent::l1, Error};
 
 pub(crate) fn sign_l1_action(
@@ -115,6 +114,7 @@ pub(crate) fn sign_multi_sig_action(
 
     let mut bytes = rmp_serde::to_vec_named(&action_without_type)
         .map_err(|e| Error::RmpParse(e.to_string()))?;
+    println!("{}", action_without_type);
 
     bytes.extend(nonce.to_be_bytes());
 

--- a/src/signature/create_signature.rs
+++ b/src/signature/create_signature.rs
@@ -1,7 +1,6 @@
 use crate::exchange::MultiSigAction;
 use crate::{eip712::Eip712, prelude::*, signature::agent::l1, Actions, Error};
 use alloy::{
-    hex,
     primitives::B256,
     signers::{local::PrivateKeySigner, Signature, SignerSync},
 };
@@ -114,7 +113,6 @@ pub(crate) fn sign_multi_sig_action(
 
     let mut bytes = rmp_serde::to_vec_named(&action_without_type)
         .map_err(|e| Error::RmpParse(e.to_string()))?;
-    println!("{}", hex::encode(&bytes));
 
     bytes.extend(nonce.to_be_bytes());
 

--- a/src/signature/create_signature.rs
+++ b/src/signature/create_signature.rs
@@ -115,6 +115,7 @@ pub(crate) fn sign_multi_sig_action(
 
     let mut bytes = rmp_serde::to_vec_named(&action_without_type)
         .map_err(|e| Error::RmpParse(e.to_string()))?;
+    println!("{}", action_without_type);
 
     bytes.extend(nonce.to_be_bytes());
 

--- a/src/signature/create_signature.rs
+++ b/src/signature/create_signature.rs
@@ -115,7 +115,6 @@ pub(crate) fn sign_multi_sig_action(
 
     let mut bytes = rmp_serde::to_vec_named(&action_without_type)
         .map_err(|e| Error::RmpParse(e.to_string()))?;
-    println!("{}", action_without_type);
 
     bytes.extend(nonce.to_be_bytes());
 

--- a/src/signature/create_signature.rs
+++ b/src/signature/create_signature.rs
@@ -1,8 +1,8 @@
+use crate::{eip712::Eip712, prelude::*, signature::agent::l1, Error};
 use alloy::{
     primitives::B256,
     signers::{local::PrivateKeySigner, Signature, SignerSync},
 };
-use crate::{eip712::Eip712, prelude::*, signature::agent::l1, Error};
 
 pub(crate) fn sign_l1_action(
     wallet: &PrivateKeySigner,

--- a/src/signature/create_signature.rs
+++ b/src/signature/create_signature.rs
@@ -109,7 +109,8 @@ pub(crate) fn sign_multi_sig_action(
     // Remove the "type" field before hashing (as per Python SDK)
     let mut action_without_type = multi_sig_action.clone();
     if let Some(obj) = action_without_type.as_object_mut() {
-        obj.remove("type");
+        // Need to preserve the order of the fields
+        obj.shift_remove("type");
     }
 
     let mut bytes = rmp_serde::to_vec_named(&action_without_type)

--- a/src/signature/create_signature.rs
+++ b/src/signature/create_signature.rs
@@ -5,7 +5,7 @@ use alloy::{
     signers::{local::PrivateKeySigner, Signature, SignerSync},
 };
 
-pub(crate) fn sign_l1_action(
+pub fn sign_l1_action(
     wallet: &PrivateKeySigner,
     connection_id: B256,
     is_mainnet: bool,
@@ -49,7 +49,7 @@ pub(crate) fn sign_typed_data_multi_sig<T: Eip712>(
 }
 
 #[allow(clippy::too_many_arguments)]
-pub(crate) fn sign_multi_sig_l1_action_payload(
+pub fn sign_multi_sig_l1_action_payload(
     wallets: &[PrivateKeySigner],
     action: &Actions,
     multi_sig_user: alloy::primitives::Address,
@@ -92,7 +92,7 @@ pub(crate) fn sign_multi_sig_l1_action_payload(
 /// 1. Removes the "type" field from the multi_sig_action
 /// 2. Computes the action hash using msgpack + nonce + vault_address + expires_after
 /// 3. Creates and signs the MultiSigEnvelope
-pub(crate) fn sign_multi_sig_action(
+pub fn sign_multi_sig_action(
     wallet: &PrivateKeySigner,
     multi_sig_action: &MultiSigAction,
     vault_address: Option<alloy::primitives::Address>,

--- a/src/signature/create_signature.rs
+++ b/src/signature/create_signature.rs
@@ -10,11 +10,7 @@ pub(crate) fn sign_l1_action(
     connection_id: B256,
     is_mainnet: bool,
 ) -> Result<Signature> {
-    let source = if is_mainnet { "a" } else { "b" }.to_string();
-    let payload = l1::Agent {
-        source,
-        connectionId: connection_id,
-    };
+    let payload = l1::Agent::new(is_mainnet, connection_id);
     sign_typed_data(&payload, wallet)
 }
 

--- a/src/signature/mod.rs
+++ b/src/signature/mod.rs
@@ -5,3 +5,8 @@ pub(crate) use create_signature::{
     sign_l1_action, sign_multi_sig_action, sign_multi_sig_l1_action_payload, sign_typed_data,
     sign_typed_data_multi_sig,
 };
+
+// Public API for multi-sig signature collection
+pub use create_signature::{
+    sign_multi_sig_l1_action_single, sign_multi_sig_user_signed_action_single,
+};

--- a/src/signature/mod.rs
+++ b/src/signature/mod.rs
@@ -2,5 +2,6 @@ pub(crate) mod agent;
 mod create_signature;
 
 pub(crate) use create_signature::{
-    sign_l1_action, sign_l1_action_multi_sig, sign_typed_data, sign_typed_data_multi_sig,
+    sign_l1_action, sign_multi_sig_action, sign_multi_sig_l1_action_payload, sign_typed_data,
+    sign_typed_data_multi_sig,
 };

--- a/src/signature/mod.rs
+++ b/src/signature/mod.rs
@@ -1,4 +1,6 @@
 pub(crate) mod agent;
 mod create_signature;
 
-pub(crate) use create_signature::{sign_l1_action, sign_typed_data};
+pub(crate) use create_signature::{
+    sign_l1_action, sign_l1_action_multi_sig, sign_typed_data, sign_typed_data_multi_sig,
+};

--- a/src/signature/mod.rs
+++ b/src/signature/mod.rs
@@ -1,12 +1,11 @@
-pub(crate) mod agent;
+mod agent;
 mod create_signature;
 
-pub(crate) use create_signature::{
-    sign_l1_action, sign_multi_sig_action, sign_multi_sig_l1_action_payload, sign_typed_data,
-    sign_typed_data_multi_sig,
-};
+pub(crate) use create_signature::{sign_typed_data, sign_typed_data_multi_sig};
 
-// Public API for multi-sig signature collection
+// Public API for signature collection
+pub use agent::*;
 pub use create_signature::{
+    sign_l1_action, sign_multi_sig_action, sign_multi_sig_l1_action_payload,
     sign_multi_sig_l1_action_single, sign_multi_sig_user_signed_action_single,
 };

--- a/src/ws/ws_manager.rs
+++ b/src/ws/ws_manager.rs
@@ -197,7 +197,9 @@ impl WsManager {
                     match serde_json::to_string(&Ping { method: "ping" }) {
                         Ok(payload) => {
                             let mut writer = writer.lock().await;
-                            if let Err(err) = writer.send(protocol::Message::Text(payload)).await {
+                            if let Err(err) =
+                                writer.send(protocol::Message::Text(payload.into())).await
+                            {
                                 error!("Error pinging server: {err}")
                             }
                         }
@@ -384,7 +386,7 @@ impl WsManager {
         .map_err(|e| Error::JsonParse(e.to_string()))?;
 
         writer
-            .send(protocol::Message::Text(payload))
+            .send(protocol::Message::Text(payload.into()))
             .await
             .map_err(|e| Error::Websocket(e.to_string()))?;
         Ok(())


### PR DESCRIPTION
Built on top of #144 so that should be reviewed first.

Refactored/renamed `BaseUrl` -> `HyperliquidChain` since it better represents what it actually is after expanding where it's used.

Added `::new()` helpers on action structs so you can easily create actions with a default chain ID and generated timestamp, without exposing `next_nonce`.

This lets you build actions/signatures for a user to sign sign asynchronously.

Exposes `post` so you can relay those pre-signed actions.



